### PR TITLE
[#17] [ENG-961]  remove getVaultStates

### DIFF
--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -377,22 +377,6 @@ contract EthMultiVault is
     /*        Misc. Helpers       */
     /* -------------------------- */
 
-    /// @notice returns vault total assets and shares for all vaults
-    function getVaultStates()
-        external
-        view
-        returns (Types.VaultState[] memory states)
-    {
-        states = new Types.VaultState[](count);
-        for (uint256 i = 1; i <= count; i++) {
-            states[i - 1] = Types.VaultState({
-                id: i,
-                assets: vaults[i].totalAssets,
-                shares: vaults[i].totalShares
-            });
-        }
-    }
-
     function getVaultBalance(
         uint256 vaultId,
         address user

--- a/test/EthMultiVaultV2.sol
+++ b/test/EthMultiVaultV2.sol
@@ -370,22 +370,6 @@ contract EthMultiVaultV2 is
     /*        Misc. Helpers       */
     /* -------------------------- */
 
-    /// @notice returns vault total assets and shares for all vaults
-    function getVaultStates()
-        external
-        view
-        returns (Types.VaultState[] memory states)
-    {
-        states = new Types.VaultState[](count);
-        for (uint256 i = 1; i <= count; i++) {
-            states[i - 1] = Types.VaultState({
-                id: i,
-                assets: vaults[i].totalAssets,
-                shares: vaults[i].totalShares
-            });
-        }
-    }
-
     function getVaultBalance(
         uint256 vaultId,
         address user

--- a/test/unit/EthMultiVault/Helpers.t.sol
+++ b/test/unit/EthMultiVault/Helpers.t.sol
@@ -13,32 +13,6 @@ contract HelpersTest is EthMultiVaultBase, EthMultiVaultHelpers {
         _setUp();
     }
 
-    function testGetVaultStates() external {
-        // prank call from alice
-        // as both msg.sender and tx.origin
-        vm.startPrank(alice, alice);
-
-        // test values
-        uint256 testAtomCost = getAtomCost();
-        uint256 testMinDesposit = getMinDeposit();
-        uint256 testDespositAmount = testMinDesposit;
-
-        // execute interaction - create atoms
-        uint256 id = ethMultiVault.createAtom{value: testAtomCost}("atom1");
-
-        // execute interaction - deposit atoms
-        ethMultiVault.depositAtom{value: testDespositAmount}(alice, id);
-
-        vm.stopPrank();
-
-        Types.VaultState[] memory states = ethMultiVault.getVaultStates();
-
-        assertEq(states.length, 1);
-        assertEq(states[0].id, id);
-        assertEq(states[0].assets, vaultTotalAssets(id));
-        assertEq(states[0].shares, vaultTotalShares(id));
-    }
-
     function testMaxRedeem() external {
         // prank call from alice
         // as both msg.sender and tx.origin


### PR DESCRIPTION
**_Addresses Issue [[#17] [ENG-961] getVaultStates does not retrieve counter vaults (Informational)](https://github.com/0xIntuition/intuition-tob-audit/issues/18)_**

Removed `getVaultStates` helper function from `EthMultiVault` and from tests that included it.