### PR TITLE
[#3] [ENG-925]  remove address(this) from salt and add test for comparing addresses

### DIFF
--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -419,7 +419,7 @@ contract EthMultiVault is
             walletConfig.atomWarden
         );
         bytes memory data = abi.encodePacked(code, encodedArgs);
-        bytes32 salt = keccak256(abi.encode(address(this), id));
+        bytes32 salt = bytes32(id);
         bytes32 rawAddress = keccak256(
             abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(data))
         );
@@ -442,7 +442,7 @@ contract EthMultiVault is
         uint256 atomId
     ) external whenNotPaused returns (address atomWallet) {
         // compute salt
-        bytes32 salt = keccak256(abi.encode(address(this), atomId));
+        bytes32 salt = bytes32(atomId);
         // get creation code
         bytes memory code = type(AtomWallet).creationCode;
         // encode constructor arguments (IEntryPoint, address)

--- a/test/unit/EthMultiVault/Helpers.t.sol
+++ b/test/unit/EthMultiVault/Helpers.t.sol
@@ -83,11 +83,16 @@ contract HelpersTest is EthMultiVaultBase, EthMultiVaultHelpers {
         address atomWalletAddress = ethMultiVault.deployAtomWallet(atomId);
         address payable atomWallet = payable(atomWalletAddress);
 
+        address computedAddress = ethMultiVault.computeAtomWalletAddr(atomId);
+
         // verify the returned atomWallet address is not zero
         assertNotEq(atomWallet, address(0));
 
         // verify atomWallet is a contract
         assertTrue(isContract(atomWallet));
+
+        // verify the computed address matches the actual wallet address
+        assertEq(computedAddress, atomWalletAddress);
     }
 
     function isContract(address _addr) internal view returns (bool) {


### PR DESCRIPTION
**_Addresses [[#3] [ENG-925] Salt contains superfluous address(this) (Informational)](https://github.com/0xIntuition/intuition-tob-audit/issues/4)_**

Remove the `address(this)` as a salt parameter from `deployAtomWallet` and `computeAtomWalletAddr` functions and added a test to compare their return values to make sure they're matching. Fixes issue #4 