### PR TITLE
[#16] [ENG-960] add a check if atom exists before deploying atom wallet

### DIFF
--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -437,10 +437,13 @@ contract EthMultiVault is
     /// @notice deploy a given atom wallet
     /// @param atomId vault id of atom
     /// @return atomWallet the address of the atom wallet
-    /// NOTE: deploys an ERC4337 account (atom wallet)
+    /// NOTE: deploys an ERC4337 account (atom wallet). Reverts if the atom vault does not exist
     function deployAtomWallet(
         uint256 atomId
     ) external whenNotPaused returns (address atomWallet) {
+        if (atomId == 0 || atomId > count)
+            revert Errors.MultiVault_VaultDoesNotExist();
+
         // compute salt
         bytes32 salt = keccak256(abi.encode(address(this), atomId));
         // get creation code

--- a/test/unit/EthMultiVault/Helpers.t.sol
+++ b/test/unit/EthMultiVault/Helpers.t.sol
@@ -80,6 +80,16 @@ contract HelpersTest is EthMultiVaultBase, EthMultiVaultHelpers {
         // test values
         uint256 atomId = 1;
 
+        // should not be able to deploy atom wallet for atom that has not been created yet
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.MultiVault_VaultDoesNotExist.selector)
+        );
+        // execute interaction - deploy atom wallet
+        ethMultiVault.deployAtomWallet(atomId);
+
+        // execute interaction - create atom
+        ethMultiVault.createAtom{value: getAtomCost()}("atom1");
+
         address atomWalletAddress = ethMultiVault.deployAtomWallet(atomId);
         address payable atomWallet = payable(atomWalletAddress);
 


### PR DESCRIPTION
Added a check inside the `deployAtomWallet` function to check whether a given `atomId` has been created before deploying `AtomWallet`