### PR TITLE
[#15] [ENG-960] add atom wallet precreation check

### DIFF
--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -419,10 +419,13 @@ contract EthMultiVault is
     /// @notice deploy a given atom wallet
     /// @param atomId vault id of atom
     /// @return atomWallet the address of the atom wallet
-    /// NOTE: deploys an ERC4337 account (atom wallet)
+    /// NOTE: deploys an ERC4337 account (atom wallet). Reverts if the atom vault does not exist
     function deployAtomWallet(
         uint256 atomId
     ) external whenNotPaused returns (address atomWallet) {
+        if (atomId == 0 || atomId > count)
+            revert Errors.MultiVault_VaultDoesNotExist();
+
         // compute salt
         bytes32 salt = bytes32(atomId);
         // get creation code

--- a/test/unit/EthMultiVault/Helpers.t.sol
+++ b/test/unit/EthMultiVault/Helpers.t.sol
@@ -54,6 +54,16 @@ contract HelpersTest is EthMultiVaultBase, EthMultiVaultHelpers {
         // test values
         uint256 atomId = 1;
 
+        // should not be able to deploy atom wallet for atom that has not been created yet
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.MultiVault_VaultDoesNotExist.selector)
+        );
+        // execute interaction - deploy atom wallet
+        ethMultiVault.deployAtomWallet(atomId);
+
+        // execute interaction - create atom
+        ethMultiVault.createAtom{value: getAtomCost()}("atom1");
+
         address atomWalletAddress = ethMultiVault.deployAtomWallet(atomId);
         address payable atomWallet = payable(atomWalletAddress);
 

--- a/test/unit/EthMultiVault/UpgradeTo.t.sol
+++ b/test/unit/EthMultiVault/UpgradeTo.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.18;
 
 import "forge-std/Test.sol";
 import {EthMultiVault} from "src/EthMultiVault.sol";
-import {EthMultiVaultV2} from "src/test/EthMultiVaultV2.sol";
+import {EthMultiVaultV2} from "../../EthMultiVaultV2.sol";
 import {IEthMultiVault} from "src/interfaces/IEthMultiVault.sol";
 import {IPermit2} from "src/interfaces/IPermit2.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";


### PR DESCRIPTION
Added a check inside the `deployAtomWallet` function to check whether the given `atomId` has been created before deploying `AtomWallet`. Reverts if the `atomId` is out of range of (1, `count`)

