### PR TITLE
change license to BUSL and scrub 'Intuition' from the comments

### DIFF
--- a/src/AtomWallet.sol
+++ b/src/AtomWallet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.18;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -10,9 +10,7 @@ import {Errors} from "./libraries/Errors.sol";
 
 /**
  * @title  AtomWallet
- * @author 0xIntuition
- * @notice Core contract of the Intuition protocol. This contract is the abstract account
- *         associated to a corresponding atom.
+ * @notice This contract is an abstract account associated with a corresponding atom.
  */
 contract AtomWallet is Initializable, BaseAccount, OwnableUpgradeable {
     using ECDSAUpgradeable for bytes32;

--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.18;
 
 import {IEthMultiVault} from "src/interfaces/IEthMultiVault.sol";
@@ -17,9 +17,7 @@ import {Errors} from "src/libraries/Errors.sol";
 
 /**
  * @title  EthMultiVault
- * @author 0xIntuition
- * @notice Core contract of the Intuition protocol. Manages the creation and management of vaults
- *         associated to Atom's & Triples
+ * @notice Manages the creation and management of vaults associated with atoms & triples.
  */
 contract EthMultiVault is
     IEthMultiVault,

--- a/src/interfaces/IEthMultiVault.sol
+++ b/src/interfaces/IEthMultiVault.sol
@@ -1,10 +1,9 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.18;
 
 import {IPermit2} from "./IPermit2.sol";
 
 /// @title IVaultManager
-/// @author 0xIntuition
 /// @notice Interface for managing many ERC4626 style vaults in a single contract
 interface IEthMultiVault {
     /* =================================================== */
@@ -14,7 +13,7 @@ interface IEthMultiVault {
     struct GeneralConfig {
         /// @notice Admin address
         address admin;
-        /// @notice Intuition Protocol multisig address
+        /// @notice Protocol vault address
         address protocolVault;
         /// @notice Fees are calculated by amount * (fee / feeDenominator);
         uint256 feeDenominator;

--- a/src/interfaces/IPermit2.sol
+++ b/src/interfaces/IPermit2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.18;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -1,9 +1,8 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.18;
 
-/// @title  Errors
-/// @author 0xIntuition
-/// @notice Library containing all custom errors detailing cases where the intuition core protocol may revert.
+/// @title  Errors Library
+/// @notice Library containing all custom errors detailing cases in which the contracts should revert
 library Errors {
     /*//////////// MULTIVAULT ERRORS //////////////////////////////////////////////////////*/
 

--- a/src/libraries/Types.sol
+++ b/src/libraries/Types.sol
@@ -1,9 +1,8 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.18;
 
-/// @title Intuition Types Library
-/// @author 0xIntuition
-/// @notice Library containing types used throughout the Intuition core protocol
+/// @title Types Library
+/// @notice Library containing types used in the EthMultiVault contract
 library Types {
     /// @notice Vault state
     struct VaultState {


### PR DESCRIPTION
Created a PR to address the remaining minor pre-deployment changes:
- Changed the license in all of our contracts from MIT to BUSL-1.1 from Uniswap v3
- Deleted references to Intuition protocol as previously discussed for the Memekek launch
- Also name of the repository has been changed from `intuition-tob-audit` to `intuition-beta-contracts`