### PR TITLE
draft implementation for the underlying atom redemption [WIP]

### DIFF
--- a/src/interfaces/IEthMultiVault.sol
+++ b/src/interfaces/IEthMultiVault.sol
@@ -423,11 +423,12 @@ interface IEthMultiVault {
     /// @return totalUserAssets total amount of assets user would receive if redeeming 'shares', not including fees
     /// @return assetsForReceiver amount of assets that is redeemable by the receiver
     /// @return protocolFees amount of assets that would be sent to the protocol vault
+    /// @return atomDepositFraction amount of assets that would be used as atom deposit fraction
     /// @return exitFees amount of assets that would be charged for the exit fee
     function getRedeemAssetsAndFees(uint256 shares, uint256 id)
         external
         view
-        returns (uint256, uint256, uint256, uint256);
+        returns (uint256, uint256, uint256, uint256, uint256);
 
     /// @notice returns amount of assets that would be charged for the entry fee given an amount of 'assets' provided
     ///

--- a/test/EthMultiVaultBase.sol
+++ b/test/EthMultiVaultBase.sol
@@ -143,10 +143,19 @@ contract EthMultiVaultBase is Test, IEthMultiVaultEvents {
         return ethMultiVault.protocolFeeAmount(assets, id);
     }
 
-    function getRedeemFees(uint256 shares, uint256 id) public view returns (uint256, uint256, uint256, uint256) {
-        (uint256 totalUserAssets, uint256 assetsForReceiver, uint256 protocolFee, uint256 exitFees) =
-            ethMultiVault.getRedeemAssetsAndFees(shares, id);
-        return (totalUserAssets, assetsForReceiver, protocolFee, exitFees);
+    function getRedeemFees(uint256 shares, uint256 id)
+        public
+        view
+        returns (uint256, uint256, uint256, uint256, uint256)
+    {
+        (
+            uint256 totalUserAssets,
+            uint256 assetsForReceiver,
+            uint256 protocolFee,
+            uint256 atomDepositFraction,
+            uint256 exitFees
+        ) = ethMultiVault.getRedeemAssetsAndFees(shares, id);
+        return (totalUserAssets, assetsForReceiver, protocolFee, atomDepositFraction, exitFees);
     }
 
     function currentSharePrice(uint256 id) public view returns (uint256) {

--- a/test/invariant/actors/EthMultiVaultActor.sol
+++ b/test/invariant/actors/EthMultiVaultActor.sol
@@ -52,9 +52,9 @@ contract EthMultiVaultActor is Test, EthMultiVaultHelpers {
     }
 
     function getAssetsForReceiverBeforeFees(uint256 shares, uint256 vaultId) public view returns (uint256) {
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 atomDepositFraction, uint256 exitFees) =
             actEthMultiVault.getRedeemAssetsAndFees(shares, vaultId);
-        return calculatedAssetsForReceiver + protocolFees + exitFees;
+        return calculatedAssetsForReceiver + protocolFees + atomDepositFraction + exitFees;
     }
 
     function createAtom(bytes calldata _data, uint256 msgValue, uint256 actorIndexSeed)

--- a/test/invariant/actors/EthMultiVaultSingleVaultActor.sol
+++ b/test/invariant/actors/EthMultiVaultSingleVaultActor.sol
@@ -52,9 +52,9 @@ contract EthMultiVaultSingleVaultActor is Test, EthMultiVaultHelpers {
     }
 
     function getAssetsForReceiverBeforeFees(uint256 shares, uint256 vaultId) public view returns (uint256) {
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 atomDepositFraction, uint256 exitFees) =
             actEthMultiVault.getRedeemAssetsAndFees(shares, vaultId);
-        return calculatedAssetsForReceiver + protocolFees + exitFees;
+        return calculatedAssetsForReceiver + protocolFees + atomDepositFraction + exitFees;
     }
 
     function depositAtom(address _receiver, uint256 msgValue, uint256 actorIndexSeed)

--- a/test/unit/EthMultiVault/EmergencyRedeemTriple.t.sol
+++ b/test/unit/EthMultiVault/EmergencyRedeemTriple.t.sol
@@ -54,7 +54,8 @@ contract EmergencyRedeemTripleTest is EthMultiVaultBase, EthMultiVaultHelpers {
 
         vm.startPrank(bob, bob);
 
-        (,, uint256 protocolFees, uint256 exitFees) = getRedeemFees(userSharesBeforeRedeem, id);
+        (,, uint256 protocolFees, uint256 atomDepositFraction, uint256 exitFees) =
+            getRedeemFees(userSharesBeforeRedeem, id);
 
         // protocol fees and exit fees are not charged in the emergency redeem
         assertEq(protocolFees, 0);

--- a/test/unit/EthMultiVault/EmergencyReedemAtom.t.sol
+++ b/test/unit/EthMultiVault/EmergencyReedemAtom.t.sol
@@ -48,7 +48,8 @@ contract EmergencyRedeemAtomTest is EthMultiVaultBase, EthMultiVaultHelpers {
 
         vm.startPrank(bob, bob);
 
-        (,, uint256 protocolFees, uint256 exitFees) = getRedeemFees(userSharesBeforeRedeem, id);
+        (,, uint256 protocolFees, uint256 atomDepositFraction, uint256 exitFees) =
+            getRedeemFees(userSharesBeforeRedeem, id);
 
         // protocol fees and exit fees are not charged in the emergency redeem
         assertEq(protocolFees, 0);

--- a/test/unit/EthMultiVault/RedeemAtom.t.sol
+++ b/test/unit/EthMultiVault/RedeemAtom.t.sol
@@ -39,7 +39,7 @@ contract RedeemAtomTest is EthMultiVaultBase, EthMultiVaultHelpers {
         uint256 userSharesBeforeRedeem = getSharesInVault(id, bob);
         uint256 userBalanceBeforeRedeem = address(bob).balance;
 
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees,, uint256 exitFees) =
             ethMultiVault.getRedeemAssetsAndFees(userSharesBeforeRedeem, id);
         uint256 assetsForReceiverBeforeFees = calculatedAssetsForReceiver + protocolFees + exitFees;
 

--- a/test/unit/EthMultiVault/RedeemTriple.t.sol
+++ b/test/unit/EthMultiVault/RedeemTriple.t.sol
@@ -45,7 +45,7 @@ contract RedeemTripleTest is EthMultiVaultBase, EthMultiVaultHelpers {
         uint256 userSharesBeforeRedeem = getSharesInVault(id, bob);
         uint256 userBalanceBeforeRedeem = address(bob).balance;
 
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 atomDepositFraction, uint256 exitFees) =
             ethMultiVault.getRedeemAssetsAndFees(userSharesBeforeRedeem, id);
         uint256 assetsForReceiverBeforeFees = calculatedAssetsForReceiver + protocolFees + exitFees;
 


### PR DESCRIPTION
This PR aims to address the missing feature of redeeming shares from the underlying atoms as a part of the `redeemTriple` functionality. This is work in progress, as we're not still 100% sure do we want to have this functionality or not, and we also may end up replicating it in an alternative way (e.g. to do a multicall on the frontend).

 For this PR to be complete, the following needs to be completed:

1. Logic from the new method called `_redeemUnderlyingAtoms` needs to reviewed
2. "Stack too deep" issue needs to be fixed for the `_redeem` method 
3. Both unit and invariant tests for `redeemTriple` will need to be updated