### PR TITLE
events refactoring

### DIFF
--- a/src/interfaces/IEthMultiVault.sol
+++ b/src/interfaces/IEthMultiVault.sol
@@ -126,6 +126,7 @@ interface IEthMultiVault {
     /// @notice Emitted upon the withdrawal of assets from the vault by redeeming shares
     ///
     /// @param sender initializer of the withdrawal (owner of the shares)
+    /// @param receiver beneficiary of the withdrawn assets (can be different from the sender)
     /// @param vaultBalance total assets held in the vault
     /// @param assetsForReceiver quantity of assets withdrawn by the receiver
     /// @param shares quantity of shares redeemed
@@ -133,6 +134,7 @@ interface IEthMultiVault {
     /// @param vaultId vault id of the vault being redeemed from
     event Redeemed(
         address indexed sender,
+        address indexed receiver,
         uint256 vaultBalance,
         uint256 assetsForReceiver,
         uint256 shares,


### PR DESCRIPTION
A small events refactoring PR as per Simon's recommendations:

1. Standardized the `id` and `vaultId` variables to be named just `vaultId` for clarity and simplicity in all emitted events
2. Got rid of the owner in the `Redeemed` event, since `sender` and `owner` are always equal