### PR TITLE
standardize fee names to singular

### DIFF
--- a/_playground/EthMultiVaultV2.sol
+++ b/_playground/EthMultiVaultV2.sol
@@ -150,19 +150,19 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
     /// @return totalFees total fees that would be charged for depositing 'assets' into a vault
     function getDepositFees(uint256 assets, uint256 id) public view returns (uint256) {
         uint256 protocolFee = protocolFeeAmount(assets, id);
-        uint256 userAssetsAfterProtocolFees = assets - protocolFee;
+        uint256 userAssetsAfterprotocolFee = assets - protocolFee;
 
-        uint256 atomDepositFraction = atomDepositFractionAmount(userAssetsAfterProtocolFees, id);
-        uint256 userAssetsAfterProtocolFeesAndAtomDepositFraction = userAssetsAfterProtocolFees - atomDepositFraction;
+        uint256 atomDepositFraction = atomDepositFractionAmount(userAssetsAfterprotocolFee, id);
+        uint256 userAssetsAfterprotocolFeeAndAtomDepositFraction = userAssetsAfterprotocolFee - atomDepositFraction;
 
-        uint256 entryFee = entryFeeAmount(userAssetsAfterProtocolFeesAndAtomDepositFraction, id);
+        uint256 entryFee = entryFeeAmount(userAssetsAfterprotocolFeeAndAtomDepositFraction, id);
         uint256 totalFees = protocolFee + atomDepositFraction + entryFee;
 
         return totalFees;
     }
 
     /// @notice returns the shares for recipient and other important values when depositing 'assets' into a vault
-    /// @param assets amount of `assets` to calculate fees on (should always be msg.value - protocolFees)
+    /// @param assets amount of `assets` to calculate fees on (should always be msg.value - protocolFee)
     /// @param id vault id to get corresponding fees for
     /// @return totalAssetsDelta changes in vault's total assets
     /// @return sharesForReceiver changes in vault's total shares (shares owed to receiver)
@@ -202,8 +202,8 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
     /// @param id vault id to get corresponding fees for
     /// @return totalUserAssets total amount of assets user would receive if redeeming 'shares', not including fees
     /// @return assetsForReceiver amount of assets that is redeemable by the receiver
-    /// @return protocolFees amount of assets that would be sent to the protocol vault
-    /// @return exitFees amount of assets that would be charged for the exit fee
+    /// @return protocolFee amount of assets that would be sent to the protocol vault
+    /// @return exitFee amount of assets that would be charged for the exit fee
     function getRedeemAssetsAndFees(uint256 shares, uint256 id)
         public
         view
@@ -212,8 +212,8 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
         uint256 remainingShares = vaults[id].totalShares - shares;
 
         uint256 assetsForReceiverBeforeFees = convertToAssets(shares, id);
-        uint256 protocolFees;
-        uint256 exitFees;
+        uint256 protocolFee;
+        uint256 exitFee;
 
         /*
          * if the redeem amount results in a zero share balance for
@@ -223,21 +223,21 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
          * contract is paused), no exit fees are charged either.
          */
         if (paused()) {
-            exitFees = 0;
-            protocolFees = 0;
+            exitFee = 0;
+            protocolFee = 0;
         } else if (remainingShares == generalConfig.minShare) {
-            exitFees = 0;
-            protocolFees = protocolFeeAmount(assetsForReceiverBeforeFees, id);
+            exitFee = 0;
+            protocolFee = protocolFeeAmount(assetsForReceiverBeforeFees, id);
         } else {
-            protocolFees = protocolFeeAmount(assetsForReceiverBeforeFees, id);
-            uint256 assetsForReceiverAfterProtocolFees = assetsForReceiverBeforeFees - protocolFees;
-            exitFees = exitFeeAmount(assetsForReceiverAfterProtocolFees, id);
+            protocolFee = protocolFeeAmount(assetsForReceiverBeforeFees, id);
+            uint256 assetsForReceiverAfterprotocolFee = assetsForReceiverBeforeFees - protocolFee;
+            exitFee = exitFeeAmount(assetsForReceiverAfterprotocolFee, id);
         }
 
         uint256 totalUserAssets = assetsForReceiverBeforeFees;
-        uint256 assetsForReceiver = assetsForReceiverBeforeFees - exitFees - protocolFees;
+        uint256 assetsForReceiver = assetsForReceiverBeforeFees - exitFee - protocolFee;
 
-        return (totalUserAssets, assetsForReceiver, protocolFees, exitFees);
+        return (totalUserAssets, assetsForReceiver, protocolFee, exitFee);
     }
 
     /// @notice calculates fee on raw amount
@@ -254,8 +254,8 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
     /// @return feeAmount amount of assets that would be charged for the entry fee
     /// NOTE: if the vault being deposited on has a vault total shares of 0, the entry fee is not applied
     function entryFeeAmount(uint256 assets, uint256 id) public view returns (uint256) {
-        uint256 entryFees = vaultFees[id].entryFee;
-        uint256 feeAmount = _feeOnRaw(assets, entryFees == 0 ? vaultFees[0].entryFee : entryFees);
+        uint256 entryFee = vaultFees[id].entryFee;
+        uint256 feeAmount = _feeOnRaw(assets, entryFee == 0 ? vaultFees[0].entryFee : entryFee);
         return feeAmount;
     }
 
@@ -266,8 +266,8 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
     /// NOTE: if the vault  being redeemed from given the shares to redeem results in a total shares after of 0,
     ///       the exit fee is not applied
     function exitFeeAmount(uint256 assets, uint256 id) public view returns (uint256) {
-        uint256 exitFees = vaultFees[id].exitFee;
-        uint256 feeAmount = _feeOnRaw(assets, exitFees == 0 ? vaultFees[0].exitFee : exitFees);
+        uint256 exitFee = vaultFees[id].exitFee;
+        uint256 feeAmount = _feeOnRaw(assets, exitFee == 0 ? vaultFees[0].exitFee : exitFee);
         return feeAmount;
     }
 
@@ -277,8 +277,8 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
     /// @param id vault id to get corresponding fees for
     /// @return feeAmount amount of assets that would be charged by vault on protocol fee
     function protocolFeeAmount(uint256 assets, uint256 id) public view returns (uint256) {
-        uint256 protocolFees = vaultFees[id].protocolFee;
-        uint256 feeAmount = _feeOnRaw(assets, protocolFees == 0 ? vaultFees[0].protocolFee : protocolFees);
+        uint256 protocolFee = vaultFees[id].protocolFee;
+        uint256 feeAmount = _feeOnRaw(assets, protocolFee == 0 ? vaultFees[0].protocolFee : protocolFee);
         return feeAmount;
     }
 
@@ -607,13 +607,13 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
         uint256 protocolDepositFee = protocolFeeAmount(userDeposit, id);
 
         // calculate user deposit after protocol fees
-        uint256 userDepositAfterProtocolFees = userDeposit - protocolDepositFee;
+        uint256 userDepositAfterprotocolFee = userDeposit - protocolDepositFee;
 
         // deposit user funds into vault and mint shares for the user and shares for the zero address
         _depositOnVaultCreation(
             id,
             msg.sender, // receiver
-            userDepositAfterProtocolFees
+            userDepositAfterprotocolFee
         );
 
         // get atom wallet address for the corresponding atom
@@ -749,7 +749,7 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
         uint256 protocolDepositFee = protocolFeeAmount(userDeposit, id);
 
         // calculate user deposit after protocol fees
-        uint256 userDepositAfterProtocolFees = userDeposit - protocolDepositFee;
+        uint256 userDepositAfterprotocolFee = userDeposit - protocolDepositFee;
 
         // map the resultant triple hash to the new vault ID of the triple
         triplesByHash[hash] = id;
@@ -760,13 +760,13 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
         // set this new triple's vault ID as true in the IsTriple mapping as well as its counter
         isTriple[id] = true;
 
-        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterProtocolFees, id);
+        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterprotocolFee, id);
 
         // give the user shares in the positive triple vault
         _depositOnVaultCreation(
             id,
             msg.sender, // receiver
-            userDepositAfterProtocolFees - atomDepositFraction
+            userDepositAfterprotocolFee - atomDepositFraction
         );
 
         // deposit assets into each underlying atom vault and mint shares for the receiver
@@ -818,13 +818,13 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
             revert Errors.MultiVault_MinimumDeposit();
         }
 
-        uint256 protocolFees = protocolFeeAmount(msg.value, id);
-        uint256 userDepositAfterProtocolFees = msg.value - protocolFees;
+        uint256 protocolFee = protocolFeeAmount(msg.value, id);
+        uint256 userDepositAfterprotocolFee = msg.value - protocolFee;
 
         // deposit eth into vault and mint shares for the receiver
-        uint256 shares = _deposit(receiver, id, userDepositAfterProtocolFees);
+        uint256 shares = _deposit(receiver, id, userDepositAfterprotocolFee);
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         return shares;
     }
@@ -849,7 +849,7 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
             withdraw shares from vault, returning the amount of
             assets to be transferred to the receiver
         */
-        (uint256 assets, uint256 protocolFees) = _redeem(id, msg.sender, shares);
+        (uint256 assets, uint256 protocolFee) = _redeem(id, msg.sender, shares);
 
         // transfer eth to receiver factoring in fees/shares
         (bool success,) = payable(receiver).call{value: assets}("");
@@ -857,7 +857,7 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
             revert Errors.MultiVault_TransferFailed();
         }
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         return assets;
     }
@@ -893,16 +893,16 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
             revert Errors.MultiVault_MinimumDeposit();
         }
 
-        uint256 protocolFees = protocolFeeAmount(msg.value, id);
-        uint256 userDepositAfterProtocolFees = msg.value - protocolFees;
+        uint256 protocolFee = protocolFeeAmount(msg.value, id);
+        uint256 userDepositAfterprotocolFee = msg.value - protocolFee;
 
         // deposit eth into vault and mint shares for the receiver
-        uint256 shares = _deposit(receiver, id, userDepositAfterProtocolFees);
+        uint256 shares = _deposit(receiver, id, userDepositAfterprotocolFee);
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         // distribute atom shares for all 3 atoms that underly the triple
-        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterProtocolFees, id);
+        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterprotocolFee, id);
         _depositAtomFraction(id, receiver, atomDepositFraction);
 
         return shares;
@@ -925,7 +925,7 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
             withdraw shares from vault, returning the amount of
             assets to be transferred to the receiver
         */
-        (uint256 assets, uint256 protocolFees) = _redeem(id, msg.sender, shares);
+        (uint256 assets, uint256 protocolFee) = _redeem(id, msg.sender, shares);
 
         // transfer eth to receiver factoring in fees/shares
         (bool success,) = payable(receiver).call{value: assets}("");
@@ -933,7 +933,7 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
             revert Errors.MultiVault_TransferFailed();
         }
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         return assets;
     }
@@ -1073,7 +1073,7 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
     /// @dev redeem shares out of a given vault
     /// change the vault's total assets, total shares and balanceOf mappings to reflect the withdrawal
     /// @return assetsForReceiver the amount of assets/eth to be transferred to the receiver
-    /// @return protocolFees the amount of protocol fees deducted
+    /// @return protocolFee the amount of protocol fees deducted
     function _redeem(uint256 id, address owner, uint256 shares) internal returns (uint256, uint256) {
         if (shares == 0) {
             revert Errors.MultiVault_DepositOrWithdrawZeroShares();
@@ -1088,21 +1088,21 @@ contract EthMultiVaultV2 is IEthMultiVault, Initializable, ReentrancyGuardUpgrad
             revert Errors.MultiVault_InsufficientRemainingSharesInVault(remainingShares);
         }
 
-        (, uint256 assetsForReceiver, uint256 protocolFees, uint256 exitFees) = getRedeemAssetsAndFees(shares, id);
+        (, uint256 assetsForReceiver, uint256 protocolFee, uint256 exitFee) = getRedeemAssetsAndFees(shares, id);
 
         // set vault totals (assets and shares)
         _setVaultTotals(
             id,
-            vaults[id].totalAssets - (assetsForReceiver + protocolFees), // totalAssetsDelta
+            vaults[id].totalAssets - (assetsForReceiver + protocolFee), // totalAssetsDelta
             vaults[id].totalShares - shares // totalSharesDelta
         );
 
         // burn shares, then transfer assets to receiver
         _burn(owner, id, shares);
 
-        emit Redeemed(msg.sender, owner, vaults[id].balanceOf[owner], assetsForReceiver, shares, exitFees, id);
+        emit Redeemed(msg.sender, owner, vaults[id].balanceOf[owner], assetsForReceiver, shares, exitFee, id);
 
-        return (assetsForReceiver, protocolFees);
+        return (assetsForReceiver, protocolFee);
     }
 
     /// @dev mint vault shares of vault ID `id` to address `to`

--- a/_playground/ethmultivault.py
+++ b/_playground/ethmultivault.py
@@ -32,11 +32,11 @@ def createAtom(value: Decimal) -> tuple[Decimal, Decimal, Decimal, Decimal, Deci
   # Variables
   userDeposit = value - atomCost
   protocolFeeAmount = math.ceil(userDeposit * Decimal(protocolFee) / Decimal(feeDenominator))
-  userDepositAfterProtocolFees = userDeposit - Decimal(protocolFeeAmount)
+  userDepositAfterprotocolFee = userDeposit - Decimal(protocolFeeAmount)
 
   # Atom vault
-  userShares = userDepositAfterProtocolFees
-  totalShares = userDepositAfterProtocolFees + Decimal(atomWalletInitialDepositAmount) + Decimal(minShare)
+  userShares = userDepositAfterprotocolFee
+  totalShares = userDepositAfterprotocolFee + Decimal(atomWalletInitialDepositAmount) + Decimal(minShare)
   totalAssets = totalShares
 
   # Addresses
@@ -50,10 +50,10 @@ def createTriple(value: Decimal) -> tuple[Decimal, Decimal, Decimal, Decimal, De
   # Variables
   userDeposit = value - tripleCost
   protocolFeeAmount = math.ceil(userDeposit * Decimal(protocolFee) / Decimal(feeDenominator))
-  userDepositAfterProtocolFees = userDeposit - Decimal(protocolFeeAmount)
-  atomDepositFraction = math.floor(userDepositAfterProtocolFees * Decimal(atomDepositFractionForTriple) / Decimal(feeDenominator))
+  userDepositAfterprotocolFee = userDeposit - Decimal(protocolFeeAmount)
+  atomDepositFraction = math.floor(userDepositAfterprotocolFee * Decimal(atomDepositFractionForTriple) / Decimal(feeDenominator))
   perAtom = math.floor(atomDepositFraction / Decimal(3))
-  userAssetsAfterAtomDepositFraction = userDepositAfterProtocolFees - atomDepositFraction
+  userAssetsAfterAtomDepositFraction = userDepositAfterprotocolFee - atomDepositFraction
   entryFeeAmount = math.floor(perAtom * Decimal(entryFee) / Decimal(feeDenominator))
   assetsForTheAtom = perAtom - entryFeeAmount
   userSharesAfterTotalFees = assetsForTheAtom # assuming current price = 1 ether
@@ -87,9 +87,9 @@ def createTriple(value: Decimal) -> tuple[Decimal, Decimal, Decimal, Decimal, De
 def depositAtom(value: Decimal, totalAssets: Decimal, totalShares: Decimal) -> tuple[Decimal, Decimal, Decimal, Decimal]:
   # Variables
   protocolFeeAmount = math.ceil(value * Decimal(protocolFee) / Decimal(feeDenominator))
-  userDepositAfterProtocolFees = value - Decimal(protocolFeeAmount)
-  entryFeeAmount = math.floor(userDepositAfterProtocolFees * Decimal(entryFee) / Decimal(feeDenominator))
-  assetsForTheAtom = userDepositAfterProtocolFees - entryFeeAmount
+  userDepositAfterprotocolFee = value - Decimal(protocolFeeAmount)
+  entryFeeAmount = math.floor(userDepositAfterprotocolFee * Decimal(entryFee) / Decimal(feeDenominator))
+  assetsForTheAtom = userDepositAfterprotocolFee - entryFeeAmount
   userSharesForTheAtom = math.floor((assetsForTheAtom * totalShares) / totalAssets)
 
   # Atom vault
@@ -105,9 +105,9 @@ def depositAtom(value: Decimal, totalAssets: Decimal, totalShares: Decimal) -> t
 def depositTriple(value: Decimal, totalAssets: Decimal, totalShares: Decimal, totalAssetsAtom: Decimal, totalSharesAtom: Decimal) -> tuple[Decimal, Decimal, Decimal, Decimal, Decimal, Decimal, Decimal]:
   # Variables for triple
   protocolFeeAmount = math.ceil(value * Decimal(protocolFee) / Decimal(feeDenominator))
-  userDepositAfterProtocolFees = value - Decimal(protocolFeeAmount)
-  atomDepositFraction = math.floor(userDepositAfterProtocolFees * Decimal(atomDepositFractionForTriple) / Decimal(feeDenominator))
-  userAssetsAfterAtomDepositFraction = userDepositAfterProtocolFees - atomDepositFraction
+  userDepositAfterprotocolFee = value - Decimal(protocolFeeAmount)
+  atomDepositFraction = math.floor(userDepositAfterprotocolFee * Decimal(atomDepositFractionForTriple) / Decimal(feeDenominator))
+  userAssetsAfterAtomDepositFraction = userDepositAfterprotocolFee - atomDepositFraction
   if (totalShares == minShare):
     entryFeeAmount = 0
   else:
@@ -159,16 +159,16 @@ def redeem(shares: Decimal, totalAssets: Decimal, totalShares: Decimal):
     userAssets = math.floor((shares * totalAssets) / totalShares)
 
   protocolFeeAmount = math.ceil(Decimal(userAssets) * Decimal(protocolFee) / Decimal(feeDenominator))
-  userAssetsAfterProtocolFees = Decimal(userAssets) - Decimal(protocolFeeAmount)
+  userAssetsAfterprotocolFee = Decimal(userAssets) - Decimal(protocolFeeAmount)
 
   if (totalShares - shares == minShare):
     exitFeeAmount = 0
   else:
-    exitFeeAmount = math.ceil(userAssetsAfterProtocolFees * Decimal(exitFee) / Decimal(feeDenominator))
+    exitFeeAmount = math.ceil(userAssetsAfterprotocolFee * Decimal(exitFee) / Decimal(feeDenominator))
 
-  userAssetsAfterExitFees = userAssetsAfterProtocolFees - Decimal(exitFeeAmount)
+  userAssetsAfterexitFee = userAssetsAfterprotocolFee - Decimal(exitFeeAmount)
   
-  return (userAssetsAfterExitFees, protocolFeeAmount, exitFeeAmount)
+  return (userAssetsAfterexitFee, protocolFeeAmount, exitFeeAmount)
 
 
 ## ------------ Create Atom data ------------

--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -468,13 +468,13 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
         uint256 protocolDepositFee = protocolFeeAmount(userDeposit, id);
 
         // calculate user deposit after protocol fees
-        uint256 userDepositAfterProtocolFees = userDeposit - protocolDepositFee;
+        uint256 userDepositAfterprotocolFee = userDeposit - protocolDepositFee;
 
         // deposit user funds into vault and mint shares for the user and shares for the zero address
         _depositOnVaultCreation(
             id,
             msg.sender, // receiver
-            userDepositAfterProtocolFees
+            userDepositAfterprotocolFee
         );
 
         // get atom wallet address for the corresponding atom
@@ -616,7 +616,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
         uint256 protocolDepositFee = protocolFeeAmount(userDeposit, id);
 
         // calculate user deposit after protocol fees
-        uint256 userDepositAfterProtocolFees = userDeposit - protocolDepositFee;
+        uint256 userDepositAfterprotocolFee = userDeposit - protocolDepositFee;
 
         // map the resultant triple hash to the new vault ID of the triple
         triplesByHash[hash] = id;
@@ -627,13 +627,13 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
         // set this new triple's vault ID as true in the IsTriple mapping as well as its counter
         isTriple[id] = true;
 
-        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterProtocolFees, id);
+        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterprotocolFee, id);
 
         // give the user shares in the positive triple vault
         _depositOnVaultCreation(
             id,
             msg.sender, // receiver
-            userDepositAfterProtocolFees - atomDepositFraction
+            userDepositAfterprotocolFee - atomDepositFraction
         );
 
         // deposit assets into each underlying atom vault and mint shares for the receiver
@@ -689,13 +689,13 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             revert Errors.MultiVault_MinimumDeposit();
         }
 
-        uint256 protocolFees = protocolFeeAmount(msg.value, id);
-        uint256 userDepositAfterProtocolFees = msg.value - protocolFees;
+        uint256 protocolFee = protocolFeeAmount(msg.value, id);
+        uint256 userDepositAfterprotocolFee = msg.value - protocolFee;
 
         // deposit eth into vault and mint shares for the receiver
-        uint256 shares = _deposit(receiver, id, userDepositAfterProtocolFees);
+        uint256 shares = _deposit(receiver, id, userDepositAfterprotocolFee);
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         return shares;
     }
@@ -722,7 +722,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             withdraw shares from vault, returning the amount of
             assets to be transferred to the receiver
         */
-        (uint256 assets, uint256 protocolFees) = _redeem(id, msg.sender, receiver, shares);
+        (uint256 assets, uint256 protocolFee) = _redeem(id, msg.sender, receiver, shares);
 
         // transfer eth to receiver factoring in fees/shares
         (bool success,) = payable(receiver).call{value: assets}("");
@@ -730,7 +730,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             revert Errors.MultiVault_TransferFailed();
         }
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         return assets;
     }
@@ -768,17 +768,17 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             revert Errors.MultiVault_MinimumDeposit();
         }
 
-        uint256 protocolFees = protocolFeeAmount(msg.value, id);
-        uint256 userDepositAfterProtocolFees = msg.value - protocolFees;
+        uint256 protocolFee = protocolFeeAmount(msg.value, id);
+        uint256 userDepositAfterprotocolFee = msg.value - protocolFee;
 
         // deposit eth into vault and mint shares for the receiver
-        uint256 shares = _deposit(receiver, id, userDepositAfterProtocolFees);
+        uint256 shares = _deposit(receiver, id, userDepositAfterprotocolFee);
 
         // distribute atom shares for all 3 atoms that underly the triple
-        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterProtocolFees, id);
+        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterprotocolFee, id);
         _depositAtomFraction(id, receiver, atomDepositFraction);
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         return shares;
     }
@@ -802,7 +802,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             withdraw shares from vault, returning the amount of
             assets to be transferred to the receiver
         */
-        (uint256 assets, uint256 protocolFees) = _redeem(id, msg.sender, receiver, shares);
+        (uint256 assets, uint256 protocolFee) = _redeem(id, msg.sender, receiver, shares);
 
         // transfer eth to receiver factoring in fees/shares
         (bool success,) = payable(receiver).call{value: assets}("");
@@ -810,7 +810,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             revert Errors.MultiVault_TransferFailed();
         }
 
-        _transferFeesToProtocolVault(protocolFees);
+        _transferFeesToProtocolVault(protocolFee);
 
         return assets;
     }
@@ -966,7 +966,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
     /// @param shares the amount of shares to redeem
     ///
     /// @return assetsForReceiver the amount of assets/eth to be transferred to the receiver
-    /// @return protocolFees the amount of protocol fees deducted
+    /// @return protocolFee the amount of protocol fees deducted
     function _redeem(uint256 id, address owner, address receiver, uint256 shares) internal returns (uint256, uint256) {
         if (shares == 0) {
             revert Errors.MultiVault_DepositOrWithdrawZeroShares();
@@ -981,21 +981,21 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             revert Errors.MultiVault_InsufficientRemainingSharesInVault(vaults[id].totalShares - shares);
         }
 
-        (, uint256 assetsForReceiver, uint256 protocolFees, uint256 exitFees) = getRedeemAssetsAndFees(shares, id);
+        (, uint256 assetsForReceiver, uint256 protocolFee, uint256 exitFee) = getRedeemAssetsAndFees(shares, id);
 
         // set vault totals (assets and shares)
         _setVaultTotals(
             id,
-            vaults[id].totalAssets - (assetsForReceiver + protocolFees), // totalAssetsDelta
+            vaults[id].totalAssets - (assetsForReceiver + protocolFee), // totalAssetsDelta
             vaults[id].totalShares - shares // totalSharesDelta
         );
 
         // burn shares, then transfer assets to receiver
         _burn(owner, id, shares);
 
-        emit Redeemed(owner, receiver, vaults[id].balanceOf[owner], assetsForReceiver, shares, exitFees, id);
+        emit Redeemed(owner, receiver, vaults[id].balanceOf[owner], assetsForReceiver, shares, exitFee, id);
 
-        return (assetsForReceiver, protocolFees);
+        return (assetsForReceiver, protocolFee);
     }
 
     /// @dev mint vault shares of vault ID `id` to address `to`
@@ -1075,12 +1075,12 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
     /// @return totalFees total fees that would be charged for depositing 'assets' into a vault
     function getDepositFees(uint256 assets, uint256 id) public view returns (uint256) {
         uint256 protocolFee = protocolFeeAmount(assets, id);
-        uint256 userAssetsAfterProtocolFees = assets - protocolFee;
+        uint256 userAssetsAfterprotocolFee = assets - protocolFee;
 
-        uint256 atomDepositFraction = atomDepositFractionAmount(userAssetsAfterProtocolFees, id);
-        uint256 userAssetsAfterProtocolFeesAndAtomDepositFraction = userAssetsAfterProtocolFees - atomDepositFraction;
+        uint256 atomDepositFraction = atomDepositFractionAmount(userAssetsAfterprotocolFee, id);
+        uint256 userAssetsAfterprotocolFeeAndAtomDepositFraction = userAssetsAfterprotocolFee - atomDepositFraction;
 
-        uint256 entryFee = entryFeeAmount(userAssetsAfterProtocolFeesAndAtomDepositFraction, id);
+        uint256 entryFee = entryFeeAmount(userAssetsAfterprotocolFeeAndAtomDepositFraction, id);
         uint256 totalFees = protocolFee + atomDepositFraction + entryFee;
 
         return totalFees;
@@ -1088,7 +1088,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
 
     /// @notice returns the shares for recipient and other important values when depositing 'assets' into a vault
     ///
-    /// @param assets amount of `assets` to calculate fees on (should always be msg.value - protocolFees)
+    /// @param assets amount of `assets` to calculate fees on (should always be msg.value - protocolFee)
     /// @param id vault id to get corresponding fees for
     ///
     /// @return totalAssetsDelta changes in vault's total assets
@@ -1131,8 +1131,8 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
     ///
     /// @return totalUserAssets total amount of assets user would receive if redeeming 'shares', not including fees
     /// @return assetsForReceiver amount of assets that is redeemable by the receiver
-    /// @return protocolFees amount of assets that would be sent to the protocol vault
-    /// @return exitFees amount of assets that would be charged for the exit fee
+    /// @return protocolFee amount of assets that would be sent to the protocol vault
+    /// @return exitFee amount of assets that would be charged for the exit fee
     function getRedeemAssetsAndFees(uint256 shares, uint256 id)
         public
         view
@@ -1141,8 +1141,8 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
         uint256 remainingShares = vaults[id].totalShares - shares;
 
         uint256 assetsForReceiverBeforeFees = convertToAssets(shares, id);
-        uint256 protocolFees;
-        uint256 exitFees;
+        uint256 protocolFee;
+        uint256 exitFee;
 
         /*
          * if the redeem amount results in a zero share balance for
@@ -1152,21 +1152,21 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
          * contract is paused), no exit fees are charged either.
          */
         if (paused()) {
-            exitFees = 0;
-            protocolFees = 0;
+            exitFee = 0;
+            protocolFee = 0;
         } else if (remainingShares == generalConfig.minShare) {
-            exitFees = 0;
-            protocolFees = protocolFeeAmount(assetsForReceiverBeforeFees, id);
+            exitFee = 0;
+            protocolFee = protocolFeeAmount(assetsForReceiverBeforeFees, id);
         } else {
-            protocolFees = protocolFeeAmount(assetsForReceiverBeforeFees, id);
-            uint256 assetsForReceiverAfterProtocolFees = assetsForReceiverBeforeFees - protocolFees;
-            exitFees = exitFeeAmount(assetsForReceiverAfterProtocolFees, id);
+            protocolFee = protocolFeeAmount(assetsForReceiverBeforeFees, id);
+            uint256 assetsForReceiverAfterprotocolFee = assetsForReceiverBeforeFees - protocolFee;
+            exitFee = exitFeeAmount(assetsForReceiverAfterprotocolFee, id);
         }
 
         uint256 totalUserAssets = assetsForReceiverBeforeFees;
-        uint256 assetsForReceiver = assetsForReceiverBeforeFees - exitFees - protocolFees;
+        uint256 assetsForReceiver = assetsForReceiverBeforeFees - exitFee - protocolFee;
 
-        return (totalUserAssets, assetsForReceiver, protocolFees, exitFees);
+        return (totalUserAssets, assetsForReceiver, protocolFee, exitFee);
     }
 
     /// @notice returns amount of assets that would be charged for the entry fee given an amount of 'assets' provided
@@ -1177,8 +1177,8 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
     /// @return feeAmount amount of assets that would be charged for the entry fee
     /// NOTE: if the vault being deposited on has a vault total shares of 0, the entry fee is not applied
     function entryFeeAmount(uint256 assets, uint256 id) public view returns (uint256) {
-        uint256 entryFees = vaultFees[id].entryFee;
-        uint256 feeAmount = _feeOnRaw(assets, entryFees == 0 ? vaultFees[0].entryFee : entryFees);
+        uint256 entryFee = vaultFees[id].entryFee;
+        uint256 feeAmount = _feeOnRaw(assets, entryFee == 0 ? vaultFees[0].entryFee : entryFee);
         return feeAmount;
     }
 
@@ -1191,8 +1191,8 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
     /// NOTE: if the vault  being redeemed from given the shares to redeem results in a total shares after of 0,
     ///       the exit fee is not applied
     function exitFeeAmount(uint256 assets, uint256 id) public view returns (uint256) {
-        uint256 exitFees = vaultFees[id].exitFee;
-        uint256 feeAmount = _feeOnRaw(assets, exitFees == 0 ? vaultFees[0].exitFee : exitFees);
+        uint256 exitFee = vaultFees[id].exitFee;
+        uint256 feeAmount = _feeOnRaw(assets, exitFee == 0 ? vaultFees[0].exitFee : exitFee);
         return feeAmount;
     }
 
@@ -1204,8 +1204,8 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
     ///
     /// @return feeAmount amount of assets that would be charged by vault on protocol fee
     function protocolFeeAmount(uint256 assets, uint256 id) public view returns (uint256) {
-        uint256 protocolFees = vaultFees[id].protocolFee;
-        uint256 feeAmount = _feeOnRaw(assets, protocolFees == 0 ? vaultFees[0].protocolFee : protocolFees);
+        uint256 protocolFee = vaultFees[id].protocolFee;
+        uint256 feeAmount = _feeOnRaw(assets, protocolFee == 0 ? vaultFees[0].protocolFee : protocolFee);
         return feeAmount;
     }
 

--- a/src/interfaces/IEthMultiVault.sol
+++ b/src/interfaces/IEthMultiVault.sol
@@ -404,7 +404,7 @@ interface IEthMultiVault {
 
     /// @notice returns the shares for recipient and other important values when depositing 'assets' into a vault
     ///
-    /// @param assets amount of `assets` to calculate fees on (should always be msg.value - protocolFees)
+    /// @param assets amount of `assets` to calculate fees on (should always be msg.value - protocolFee)
     /// @param id vault id to get corresponding fees for
     ///
     /// @return totalAssetsDelta changes in vault's total assets
@@ -423,8 +423,8 @@ interface IEthMultiVault {
     ///
     /// @return totalUserAssets total amount of assets user would receive if redeeming 'shares', not including fees
     /// @return assetsForReceiver amount of assets that is redeemable by the receiver
-    /// @return protocolFees amount of assets that would be sent to the protocol vault
-    /// @return exitFees amount of assets that would be charged for the exit fee
+    /// @return protocolFee amount of assets that would be sent to the protocol vault
+    /// @return exitFee amount of assets that would be charged for the exit fee
     function getRedeemAssetsAndFees(uint256 shares, uint256 id)
         external
         view

--- a/test/EthMultiVaultBase.sol
+++ b/test/EthMultiVaultBase.sol
@@ -14,7 +14,7 @@ import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/Upgradeabl
 import {IEthMultiVaultEvents} from "./events/IEthMultiVaultEvents.sol";
 
 contract EthMultiVaultBase is Test, IEthMultiVaultEvents {
-    // msg.value - atomCreationProtocolFee - protocolFees
+    // msg.value - atomCreationProtocolFee - protocolFee
 
     /// @notice constants
     // initial eth amounts
@@ -144,9 +144,9 @@ contract EthMultiVaultBase is Test, IEthMultiVaultEvents {
     }
 
     function getRedeemFees(uint256 shares, uint256 id) public view returns (uint256, uint256, uint256, uint256) {
-        (uint256 totalUserAssets, uint256 assetsForReceiver, uint256 protocolFee, uint256 exitFees) =
+        (uint256 totalUserAssets, uint256 assetsForReceiver, uint256 protocolFee, uint256 exitFee) =
             ethMultiVault.getRedeemAssetsAndFees(shares, id);
-        return (totalUserAssets, assetsForReceiver, protocolFee, exitFees);
+        return (totalUserAssets, assetsForReceiver, protocolFee, exitFee);
     }
 
     function currentSharePrice(uint256 id) public view returns (uint256) {

--- a/test/helpers/EthMultiVaultHelpers.sol
+++ b/test/helpers/EthMultiVaultHelpers.sol
@@ -185,15 +185,15 @@ abstract contract EthMultiVaultHelpers is Test, EthMultiVaultBase {
         // calculate expected total assets delta
         uint256 userDeposit = value - getTripleCost();
         uint256 protocolDepositFee = protocolFeeAmount(userDeposit, id);
-        uint256 userDepositAfterProtocolFees = userDeposit - protocolDepositFee;
-        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterProtocolFees, id);
+        uint256 userDepositAfterprotocolFee = userDeposit - protocolDepositFee;
+        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterprotocolFee, id);
 
         uint256 sharesForZeroAddress = getMinShare();
 
-        uint256 totalAssetsDeltaExpected = userDepositAfterProtocolFees - atomDepositFraction + sharesForZeroAddress;
+        uint256 totalAssetsDeltaExpected = userDepositAfterprotocolFee - atomDepositFraction + sharesForZeroAddress;
 
         // calculate expected total shares delta
-        uint256 sharesForDepositor = userDepositAfterProtocolFees - atomDepositFraction;
+        uint256 sharesForDepositor = userDepositAfterprotocolFee - atomDepositFraction;
         uint256 totalSharesDeltaExpected = sharesForDepositor + sharesForZeroAddress;
 
         // vault's total assets should have gone up
@@ -226,14 +226,14 @@ abstract contract EthMultiVaultHelpers is Test, EthMultiVaultBase {
         uint256 protocolVaultBalanceBefore
     ) public view {
         uint256 length = ids.length;
-        uint256 protocolFees;
+        uint256 protocolFee;
 
         for (uint256 i = 0; i < length; i++) {
             // calculate expected protocol vault balance delta
-            protocolFees += getProtocolFeeAmount(valuePerAtom, i);
+            protocolFee += getProtocolFeeAmount(valuePerAtom, i);
         }
 
-        uint256 protocolVaultBalanceDeltaExpected = getAtomCreationProtocolFee() * length + protocolFees;
+        uint256 protocolVaultBalanceDeltaExpected = getAtomCreationProtocolFee() * length + protocolFee;
 
         // protocol vault's balance should have gone up
         uint256 protocolVaultBalanceDeltaGot = address(getProtocolVault()).balance - protocolVaultBalanceBefore;

--- a/test/invariant/actors/EthMultiVaultActor.sol
+++ b/test/invariant/actors/EthMultiVaultActor.sol
@@ -57,9 +57,9 @@ contract EthMultiVaultActor is Test, EthMultiVaultHelpers {
     }
 
     function getAssetsForReceiverBeforeFees(uint256 shares, uint256 vaultId) public view returns (uint256) {
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFee, uint256 exitFee) =
             actEthMultiVault.getRedeemAssetsAndFees(shares, vaultId);
-        return calculatedAssetsForReceiver + protocolFees + exitFees;
+        return calculatedAssetsForReceiver + protocolFee + exitFee;
     }
 
     function createAtom(bytes calldata data, uint256 msgValue, uint256 actorIndexSeed)
@@ -536,9 +536,9 @@ contract EthMultiVaultActor is Test, EthMultiVaultHelpers {
         uint256 userDeposit
     ) internal {
         uint256 protocolDepositFee = protocolFeeAmount(userDeposit, atomIds[0]);
-        uint256 userDepositAfterProtocolFees = userDeposit - protocolDepositFee;
+        uint256 userDepositAfterprotocolFee = userDeposit - protocolDepositFee;
 
-        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterProtocolFees, atomIds[0]);
+        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterprotocolFee, atomIds[0]);
         uint256 distributeAmountPerAtomVault = atomDepositFraction / 3;
 
         uint256 atomDepositFractionOnTripleCreationPerAtom = getAtomDepositFractionOnTripleCreation() / 3;
@@ -573,13 +573,13 @@ contract EthMultiVaultActor is Test, EthMultiVaultHelpers {
         // deposit triple
         shares = actEthMultiVault.depositTriple{value: msgValue}(receiver, vaultId);
 
-        uint256 userDepositAfterProtocolFees = msgValue - getProtocolFeeAmount(msgValue, vaultId);
+        uint256 userDepositAfterprotocolFee = msgValue - getProtocolFeeAmount(msgValue, vaultId);
 
-        checkDepositIntoVault(userDepositAfterProtocolFees, vaultId, totalAssetsBefore, totalSharesBefore);
+        checkDepositIntoVault(userDepositAfterprotocolFee, vaultId, totalAssetsBefore, totalSharesBefore);
 
         checkProtocolVaultBalance(vaultId, msgValue, protocolVaultBalanceBefore);
 
-        uint256 amountToDistribute = atomDepositFractionAmount(userDepositAfterProtocolFees, vaultId);
+        uint256 amountToDistribute = atomDepositFractionAmount(userDepositAfterprotocolFee, vaultId);
         uint256 distributeAmountPerAtomVault = amountToDistribute / 3;
 
         checkDepositIntoVault(

--- a/test/invariant/actors/EthMultiVaultSingleVaultActor.sol
+++ b/test/invariant/actors/EthMultiVaultSingleVaultActor.sol
@@ -53,9 +53,9 @@ contract EthMultiVaultSingleVaultActor is Test, EthMultiVaultHelpers {
     }
 
     function getAssetsForReceiverBeforeFees(uint256 shares, uint256 vaultId) public view returns (uint256) {
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFee, uint256 exitFee) =
             actEthMultiVault.getRedeemAssetsAndFees(shares, vaultId);
-        return calculatedAssetsForReceiver + protocolFees + exitFees;
+        return calculatedAssetsForReceiver + protocolFee + exitFee;
     }
 
     function depositAtom(address receiver, uint256 msgValue, uint256 actorIndexSeed)
@@ -289,13 +289,13 @@ contract EthMultiVaultSingleVaultActor is Test, EthMultiVaultHelpers {
 
         shares = actEthMultiVault.depositTriple{value: msgValue}(receiver, vaultId);
 
-        uint256 userDepositAfterProtocolFees = msgValue - getProtocolFeeAmount(msgValue, vaultId);
+        uint256 userDepositAfterprotocolFee = msgValue - getProtocolFeeAmount(msgValue, vaultId);
 
-        checkDepositIntoVault(userDepositAfterProtocolFees, vaultId, totalAssetsBefore, totalSharesBefore);
+        checkDepositIntoVault(userDepositAfterprotocolFee, vaultId, totalAssetsBefore, totalSharesBefore);
 
         checkProtocolVaultBalance(vaultId, msgValue, protocolVaultBalanceBefore);
 
-        uint256 amountToDistribute = atomDepositFractionAmount(userDepositAfterProtocolFees, vaultId);
+        uint256 amountToDistribute = atomDepositFractionAmount(userDepositAfterprotocolFee, vaultId);
         uint256 distributeAmountPerAtomVault = amountToDistribute / 3;
 
         checkDepositIntoVault(

--- a/test/unit/EthMultiVault/BatchCreateTriple.t.sol
+++ b/test/unit/EthMultiVault/BatchCreateTriple.t.sol
@@ -60,13 +60,13 @@ contract BatchCreateTripleTest is EthMultiVaultBase, EthMultiVaultHelpers {
         uint256 protocolVaultBalanceAfter = address(getProtocolVault()).balance;
 
         // sum up all protocol deposit fees and creation fees
-        uint256 protocolFeesTotal;
+        uint256 protocolFeeTotal;
         for (uint256 i = 0; i < triplesToCreate; i++) {
-            protocolFeesTotal += protocolFeeAmount(testDepositAmountTriple - getTripleCost(), ids[i]);
+            protocolFeeTotal += protocolFeeAmount(testDepositAmountTriple - getTripleCost(), ids[i]);
         }
 
         uint256 protocolVaultBalanceAfterLessFees =
-            protocolVaultBalanceAfter - protocolFeesTotal - (getTripleCreationProtocolFee() * triplesToCreate);
+            protocolVaultBalanceAfter - protocolFeeTotal - (getTripleCreationProtocolFee() * triplesToCreate);
         assertEq(protocolVaultBalanceBefore, protocolVaultBalanceAfterLessFees);
 
         vm.stopPrank();

--- a/test/unit/EthMultiVault/CreateTriple.t.sol
+++ b/test/unit/EthMultiVault/CreateTriple.t.sol
@@ -72,9 +72,9 @@ contract CreateTripleTest is EthMultiVaultBase, EthMultiVaultHelpers {
 
         uint256 userDeposit = testDepositAmountTriple - getTripleCost();
         uint256 protocolDepositFee = protocolFeeAmount(userDeposit, id);
-        uint256 userDepositAfterProtocolFees = userDeposit - protocolDepositFee;
+        uint256 userDepositAfterprotocolFee = userDeposit - protocolDepositFee;
 
-        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterProtocolFees, id);
+        uint256 atomDepositFraction = atomDepositFractionAmount(userDepositAfterprotocolFee, id);
         uint256 distributeAmountPerAtomVault = atomDepositFraction / 3;
 
         uint256 atomDepositFractionOnTripleCreationPerAtom = getAtomDepositFractionOnTripleCreation() / 3;

--- a/test/unit/EthMultiVault/DepositTriple.t.sol
+++ b/test/unit/EthMultiVault/DepositTriple.t.sol
@@ -43,14 +43,14 @@ contract DepositTripleTest is EthMultiVaultBase, EthMultiVaultHelpers {
         // execute interaction - deposit atoms
         ethMultiVault.depositTriple{value: testDepositAmount}(address(1), id);
 
-        uint256 userDepositAfterProtocolFees = testDepositAmount - getProtocolFeeAmount(testDepositAmount, id);
+        uint256 userDepositAfterprotocolFee = testDepositAmount - getProtocolFeeAmount(testDepositAmount, id);
 
-        checkDepositIntoVault(userDepositAfterProtocolFees, id, totalAssetsBefore, totalSharesBefore);
+        checkDepositIntoVault(userDepositAfterprotocolFee, id, totalAssetsBefore, totalSharesBefore);
 
         checkProtocolVaultBalance(id, testDepositAmount, protocolVaultBalanceBefore);
 
         // ------ Check Deposit Atom Fraction ------ //
-        uint256 amountToDistribute = atomDepositFractionAmount(userDepositAfterProtocolFees, id);
+        uint256 amountToDistribute = atomDepositFractionAmount(userDepositAfterprotocolFee, id);
         uint256 distributeAmountPerAtomVault = amountToDistribute / 3;
 
         checkDepositIntoVault(

--- a/test/unit/EthMultiVault/EmergencyRedeemTriple.t.sol
+++ b/test/unit/EthMultiVault/EmergencyRedeemTriple.t.sol
@@ -54,11 +54,11 @@ contract EmergencyRedeemTripleTest is EthMultiVaultBase, EthMultiVaultHelpers {
 
         vm.startPrank(bob, bob);
 
-        (,, uint256 protocolFees, uint256 exitFees) = getRedeemFees(userSharesBeforeRedeem, id);
+        (,, uint256 protocolFee, uint256 exitFee) = getRedeemFees(userSharesBeforeRedeem, id);
 
         // protocol fees and exit fees are not charged in the emergency redeem
-        assertEq(protocolFees, 0);
-        assertEq(exitFees, 0);
+        assertEq(protocolFee, 0);
+        assertEq(exitFee, 0);
 
         uint256 protocolVaultBalanceBeforeRedeem = address(getProtocolVault()).balance;
 

--- a/test/unit/EthMultiVault/EmergencyReedemAtom.t.sol
+++ b/test/unit/EthMultiVault/EmergencyReedemAtom.t.sol
@@ -48,11 +48,11 @@ contract EmergencyRedeemAtomTest is EthMultiVaultBase, EthMultiVaultHelpers {
 
         vm.startPrank(bob, bob);
 
-        (,, uint256 protocolFees, uint256 exitFees) = getRedeemFees(userSharesBeforeRedeem, id);
+        (,, uint256 protocolFee, uint256 exitFee) = getRedeemFees(userSharesBeforeRedeem, id);
 
         // protocol fees and exit fees are not charged in the emergency redeem
-        assertEq(protocolFees, 0);
-        assertEq(exitFees, 0);
+        assertEq(protocolFee, 0);
+        assertEq(exitFee, 0);
 
         uint256 protocolVaultBalanceBeforeRedeem = address(getProtocolVault()).balance;
 

--- a/test/unit/EthMultiVault/RedeemAtom.t.sol
+++ b/test/unit/EthMultiVault/RedeemAtom.t.sol
@@ -39,9 +39,9 @@ contract RedeemAtomTest is EthMultiVaultBase, EthMultiVaultHelpers {
         uint256 userSharesBeforeRedeem = getSharesInVault(id, bob);
         uint256 userBalanceBeforeRedeem = address(bob).balance;
 
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFee, uint256 exitFee) =
             ethMultiVault.getRedeemAssetsAndFees(userSharesBeforeRedeem, id);
-        uint256 assetsForReceiverBeforeFees = calculatedAssetsForReceiver + protocolFees + exitFees;
+        uint256 assetsForReceiverBeforeFees = calculatedAssetsForReceiver + protocolFee + exitFee;
 
         // execute interaction - redeem all atom shares for bob
         uint256 assetsForReceiver = ethMultiVault.redeemAtom(userSharesBeforeRedeem, bob, id);

--- a/test/unit/EthMultiVault/RedeemTriple.t.sol
+++ b/test/unit/EthMultiVault/RedeemTriple.t.sol
@@ -45,9 +45,9 @@ contract RedeemTripleTest is EthMultiVaultBase, EthMultiVaultHelpers {
         uint256 userSharesBeforeRedeem = getSharesInVault(id, bob);
         uint256 userBalanceBeforeRedeem = address(bob).balance;
 
-        (, uint256 calculatedAssetsForReceiver, uint256 protocolFees, uint256 exitFees) =
+        (, uint256 calculatedAssetsForReceiver, uint256 protocolFee, uint256 exitFee) =
             ethMultiVault.getRedeemAssetsAndFees(userSharesBeforeRedeem, id);
-        uint256 assetsForReceiverBeforeFees = calculatedAssetsForReceiver + protocolFees + exitFees;
+        uint256 assetsForReceiverBeforeFees = calculatedAssetsForReceiver + protocolFee + exitFee;
 
         // execute interaction - redeem all positive triple vault shares for bob
         uint256 assetsForReceiver = ethMultiVault.redeemTriple(userSharesBeforeRedeem, bob, id);


### PR DESCRIPTION
A small PR that standardizes fee naming variables from plural to singular:
1. `entryFees` --> `entryFee`
2. `exitFees` --> `exitFee`
3. `protocolFees` --> `protocolFee`