### PR TITLE
add time validation via validAfter and validUntil in the _validateSignature

### DIFF
--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -44,6 +44,7 @@ library Errors {
 
     ///////// ATOMWALLET ERRORS /////////////////////////////////////////////////////////////
 
+    error AtomWallet_InvalidCallDataLength();
     error AtomWallet_InvalidSignature();
     error AtomWallet_InvalidSignatureLength(uint256 length);
     error AtomWallet_InvalidSignatureS(bytes32 s);


### PR DESCRIPTION
This PR addresses the final remaining Hats issue ([issue #25](https://github.com/hats-finance/Intuition-0x538dbadc50cc87b281cd655f1edbc6ebda02a66a/issues/25)), which is related to the time validation in `AtomWallet` using `validUnitl` and `validAfter` in an ERC-4337 compliant way.

This is one of the suggested implementations, so definitely let me know if it needs any additional improvements.