### PR TITLE
improve condition check for AtomWallet time validation

### DIFF
--- a/src/AtomWallet.sol
+++ b/src/AtomWallet.sol
@@ -181,7 +181,8 @@ contract AtomWallet is Initializable, BaseAccount, Ownable2StepUpgradeable, Reen
     {
         (uint256 validUntil, uint256 validAfter,) = extractValidUntilAndValidAfter(userOp.callData);
 
-        if (block.timestamp < validAfter || block.timestamp > validUntil) {
+        // validUntil can be 0, meaning there won't be an expiration
+        if (block.timestamp <= validAfter || (block.timestamp >= validUntil && validUntil != 0)) {
             return SIG_VALIDATION_FAILED;
         }
 


### PR DESCRIPTION
In this short PR, I improved condition check for `AtomWallet` time validation inside of `_validateSignature`. The main improvement is the addition of the check that allows `validUntil` to be 0, meaning there won't be an expiration (i.e. it'll behave like a standard `UserOperation` without timestamp fields), making this implementation more flexible.

For more context, please check out the discussion under the [Hats issue #25](https://github.com/hats-finance/Intuition-0x538dbadc50cc87b281cd655f1edbc6ebda02a66a/issues/25).