### PR TITLE
Audit: 3.1 - Fix wrong use of prb-math

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,14 +9,9 @@ extra_output = ["storageLayout"]
 evm_version = "Cancun"
 auto_detect_remappings = false
 fs_permissions = [{ access = "read-write", path = "./out" }]
-# optimizer = true
-# optimizer_runs = 200
-# via_ir = true
-# optimizer_details = { constantOptimizer = true, yul = true, deduplicate = true }
 optimizer = true
 optimizer_runs = 200
 via_ir = true
 optimizer_details = { constantOptimizer = true, yul = true, deduplicate = true }
-ignore_warnings = true
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -118,7 +118,7 @@ contract DeployEthMultiVault is Script {
         console.logString("deployed LinearCurve.");
 
         // Deploy ProgressiveCurve
-        progressiveCurve = new ProgressiveCurve("Progressive Curve", 0.00007054e18);
+        progressiveCurve = new ProgressiveCurve("Progressive Curve", 2);
         console.logString("deployed ProgressiveCurve.");
 
         // Add curves to BondingCurveRegistry

--- a/script/GenerateCurveData.s.sol
+++ b/script/GenerateCurveData.s.sol
@@ -22,7 +22,7 @@ contract GenerateCurveData is Script {
         // Initialize all curves we want to analyze
         BaseCurve[] memory curves = new BaseCurve[](2);
         curves[0] = new LinearCurve("Linear");
-        curves[1] = new ProgressiveCurve("Progressive", 0.0025e18);
+        curves[1] = new ProgressiveCurve("Progressive", 2);
 
         // Create a metadata file to store file locations
         string memory metadata = '{"files":[';

--- a/src/BaseCurve.sol
+++ b/src/BaseCurve.sol
@@ -99,7 +99,7 @@ abstract contract BaseCurve {
     /// @notice Get the current price of a share
     ///
     /// @param totalShares Total quantity of shares already awarded by the curve
-    /// @return sharePrice The current price of a share
+    /// @return sharePrice The current price of a share, scaled by 1e18
     function currentPrice(uint256 totalShares) public view virtual returns (uint256 sharePrice);
 
     /// @notice Construct the curve with a unique name

--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -1866,7 +1866,6 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
             uint256 totalSharesInAssetSpace = _registry().convertToAssets(supply, supply, totalAssets, curveId);
             if (totalSharesInAssetSpace != 0) {
                 price = price.mulDiv(totalAssets, totalSharesInAssetSpace);
-                // console.log("currentSharePriceCurve: Price is %e", price);
                 return price;
             }
         }

--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -1842,19 +1842,19 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
 
     /// @notice returns the current share price for the given vault id
     /// @param id vault id to get corresponding share price for
-    /// @return price current share price for the given vault id, scaled by generalConfig.decimalPrecision
+    /// @return price current share price for the given vault id, scaled by 1e18
     function currentSharePrice(uint256 id) public view returns (uint256) {
         uint256 supply = vaults[id].totalShares;
         // Changing this to match exactly how convertToShares is calculated
         // This was not previously used internally in production code
-        uint256 price = supply == 0 ? 0 : vaults[id].totalAssets.mulDiv(generalConfig.decimalPrecision, supply);
+        uint256 price = supply == 0 ? 0 : vaults[id].totalAssets.mulDiv(1e18, supply);
         return price;
     }
 
     /// @notice returns the current share price for the given vault id and curve id
     /// @param id vault id to get corresponding share price for
     /// @param curveId curve id to get corresponding share price for
-    /// @return price current share price for the given vault id and curve id, scaled by generalConfig.decimalPrecision
+    /// @return price current share price for the given vault id and curve id, scaled by 1e18
     function currentSharePriceCurve(uint256 id, uint256 curveId) public view returns (uint256) {
         uint256 supply = bondingCurveVaults[id][curveId].totalShares;
         uint256 totalAssets = bondingCurveVaults[id][curveId].totalAssets;
@@ -1865,7 +1865,9 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
         if (totalAssets != 0 && supply != 0) {
             uint256 totalSharesInAssetSpace = _registry().convertToAssets(supply, supply, totalAssets, curveId);
             if (totalSharesInAssetSpace != 0) {
-                price = price.mulDiv(totalAssets * generalConfig.decimalPrecision, totalSharesInAssetSpace);
+                price = price.mulDiv(totalAssets, totalSharesInAssetSpace);
+                // console.log("currentSharePriceCurve: Price is %e", price);
+                return price;
             }
         }
         return price;
@@ -2148,6 +2150,10 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
         uint256 shares = bondingCurveVaults[vaultId][curveId].balanceOf[receiver];
         (uint256 totalUserAssets,,,) = getRedeemAssetsAndFeesCurve(shares, vaultId, curveId);
         return (shares, totalUserAssets);
+    }
+
+    function getCurveVaultState(uint256 termId, uint256 curveId) external view returns (uint256, uint256) {
+        return (bondingCurveVaults[termId][curveId].totalAssets, bondingCurveVaults[termId][curveId].totalShares);
     }
 
     /// @notice returns the Atom Wallet address for the given atom data

--- a/src/LinearCurve.sol
+++ b/src/LinearCurve.sol
@@ -125,7 +125,7 @@ contract LinearCurve is BaseCurve {
     /// @inheritdoc BaseCurve
     /// @notice In a linear curve, the base price will always be 1.  Pool ratio adjustments are dealt with in the EthMultiVault itself.
     function currentPrice(uint256 /*totalShares*/ ) public pure override returns (uint256 sharePrice) {
-        return 1;
+        return 1e18;
     }
 
     /// @inheritdoc BaseCurve

--- a/src/OffsetProgressiveCurve.sol
+++ b/src/OffsetProgressiveCurve.sol
@@ -70,7 +70,7 @@ contract OffsetProgressiveCurve is BaseCurve {
         require(slope18 > 0, "PC: Slope must be > 0");
 
         SLOPE = UD60x18.wrap(slope18);
-        HALF_SLOPE = SLOPE.div(UD60x18.wrap(2));
+        HALF_SLOPE = UD60x18.wrap(slope18 / 2);
         OFFSET = UD60x18.wrap(offset18);
         // Find max values
         // powu(2) will overflow first, therefore maximum totalShares is sqrt(MAX_UD60x18)
@@ -179,7 +179,8 @@ contract OffsetProgressiveCurve is BaseCurve {
     /// @dev And the slope ($m$) determines how quickly the price increases
     /// @dev TLDR: Each new share costs more than the last, but starting from an offset point on the curve
     function currentPrice(uint256 totalShares) public view override returns (uint256 sharePrice) {
-        return convert(convert(totalShares).add(OFFSET).mul(SLOPE));
+        console.log("OffsetProgressiveCurve: currentSharePrice is %e", convert(totalShares).add(OFFSET).mul(SLOPE).unwrap());
+        return convert(totalShares).add(OFFSET).mul(SLOPE).unwrap();
     }
 
     /// @inheritdoc BaseCurve

--- a/src/OffsetProgressiveCurve.sol
+++ b/src/OffsetProgressiveCurve.sol
@@ -179,7 +179,6 @@ contract OffsetProgressiveCurve is BaseCurve {
     /// @dev And the slope ($m$) determines how quickly the price increases
     /// @dev TLDR: Each new share costs more than the last, but starting from an offset point on the curve
     function currentPrice(uint256 totalShares) public view override returns (uint256 sharePrice) {
-        console.log("OffsetProgressiveCurve: currentSharePrice is %e", convert(totalShares).add(OFFSET).mul(SLOPE).unwrap());
         return convert(totalShares).add(OFFSET).mul(SLOPE).unwrap();
     }
 

--- a/src/OffsetProgressiveCurve.sol
+++ b/src/OffsetProgressiveCurve.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {BaseCurve} from "./BaseCurve.sol";
-import {UD60x18, ud60x18, convert} from "@prb/math/UD60x18.sol";
+import {UD60x18, ud60x18, convert, uMAX_UD60x18, uUNIT} from "@prb/math/UD60x18.sol";
 
 /**
  * @title  OffsetProgressiveCurve
@@ -45,20 +45,20 @@ contract OffsetProgressiveCurve is BaseCurve {
     /// @notice The slope of the curve, in basis points.  This is the rate at which the price of shares increases.
     /// @dev 0.0025e18 -> 25 basis points, 0.0001e18 = 1 basis point, etc etc
     /// @dev If minDeposit is 0.003 ether, this value would need to be 0.00007054e18 to avoid returning 0 shares for minDeposit assets
-    UD60x18 public immutable SLOPE;
+    UD60x18 public SLOPE;
 
     /// @notice The offset of the curve.  This value is used to snip off a portion of the beginning of the curve, realigning it to the
     /// origin.  For more details, see the preview functions.
-    UD60x18 public immutable OFFSET;
+    UD60x18 public OFFSET;
 
     /// @notice The half of the slope, used for calculations.
-    UD60x18 public immutable HALF_SLOPE;
+    UD60x18 public HALF_SLOPE;
 
     /// @dev Since powu(2) will overflow first (see slope equation), maximum totalShares is sqrt(MAX_UD60x18)
-    uint256 public immutable MAX_SHARES;
+    uint256 public MAX_SHARES;
 
     /// @dev The maximum assets is totalShares * slope / 2, because multiplication (see slope equation) would overflow beyond that point.
-    uint256 public immutable MAX_ASSETS;
+    uint256 public MAX_ASSETS;
 
     /// @notice Constructs a new ProgressiveCurve with the given name and slope
     /// @param _name The name of the curve (i.e. "Progressive Curve #465")
@@ -70,14 +70,14 @@ contract OffsetProgressiveCurve is BaseCurve {
         require(slope18 > 0, "PC: Slope must be > 0");
 
         SLOPE = UD60x18.wrap(slope18);
-        HALF_SLOPE = SLOPE.div(convert(2));
+        HALF_SLOPE = SLOPE.div(UD60x18.wrap(2));
         OFFSET = UD60x18.wrap(offset18);
         // Find max values
         // powu(2) will overflow first, therefore maximum totalShares is sqrt(MAX_UD60x18)
         // Then the maximum assets is the total shares * slope / 2, because multiplication will overflow at this point
-        UD60x18 MAX_UD60x18 = convert(type(uint256).max / 1e18);
-        MAX_SHARES = convert(MAX_UD60x18.sqrt().sub(OFFSET));
-        MAX_ASSETS = convert(MAX_UD60x18.mul(HALF_SLOPE));
+        UD60x18 MAX_SQRT = UD60x18.wrap(uMAX_UD60x18 / uUNIT);
+        MAX_SHARES = MAX_SQRT.sqrt().sub(OFFSET).unwrap();
+        MAX_ASSETS = MAX_SQRT.mul(HALF_SLOPE).unwrap();
     }
 
     /// @inheritdoc BaseCurve

--- a/src/ProgressiveCurve.sol
+++ b/src/ProgressiveCurve.sol
@@ -163,7 +163,6 @@ contract ProgressiveCurve is BaseCurve {
     /// @dev And the slope ($m$) determines how quickly the price increases
     /// @dev TLDR: Each new share costs more than the last
     function currentPrice(uint256 totalShares) public view override returns (uint256 sharePrice) {
-        // console.log("ProgressiveCurve: currentSharePrice is %e", convert(totalShares).mul(SLOPE).unwrap());
         return convert(totalShares).mul(SLOPE).unwrap();
     }
 

--- a/src/ProgressiveCurve.sol
+++ b/src/ProgressiveCurve.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {BaseCurve} from "./BaseCurve.sol";
-import {UD60x18, ud60x18} from "@prb/math/UD60x18.sol";
+import {UD60x18, ud60x18, convert} from "@prb/math/UD60x18.sol";
 
 /**
  * @title  ProgressiveCurve
@@ -63,14 +63,14 @@ contract ProgressiveCurve is BaseCurve {
         require(slope18 > 0, "PC: Slope must be > 0");
 
         SLOPE = UD60x18.wrap(slope18);
-        HALF_SLOPE = SLOPE.div(UD60x18.wrap(2));
+        HALF_SLOPE = SLOPE.div(convert(2));
 
         // Find max values
         // powu(2) will overflow first, therefore maximum totalShares is sqrt(MAX_UD60x18)
         // Then the maximum assets is the total shares * slope / 2, because multiplication will overflow at this point
-        UD60x18 MAX_UD60x18 = UD60x18.wrap(type(uint256).max / 1e18);
-        MAX_SHARES = MAX_UD60x18.sqrt().unwrap();
-        MAX_ASSETS = MAX_UD60x18.mul(HALF_SLOPE).unwrap();
+        UD60x18 MAX_UD60x18 = convert(type(uint256).max / 1e18);
+        MAX_SHARES = convert(MAX_UD60x18.sqrt());
+        MAX_ASSETS = convert(MAX_UD60x18.mul(HALF_SLOPE));
     }
 
     /// @inheritdoc BaseCurve
@@ -89,10 +89,9 @@ contract ProgressiveCurve is BaseCurve {
     {
         require(assets > 0, "Asset amount must be greater than zero");
 
-        UD60x18 currentSupplyOfShares = UD60x18.wrap(totalShares);
+        UD60x18 currentSupplyOfShares = convert(totalShares);
 
-        return currentSupplyOfShares.powu(2).add(UD60x18.wrap(assets).div(HALF_SLOPE)).sqrt().sub(currentSupplyOfShares)
-            .unwrap();
+        return convert(currentSupplyOfShares.powu(2).add(convert(assets).div(HALF_SLOPE)).sqrt().sub(currentSupplyOfShares));
     }
 
     /// @inheritdoc BaseCurve
@@ -111,11 +110,11 @@ contract ProgressiveCurve is BaseCurve {
         override
         returns (uint256 assets)
     {
-        UD60x18 currentSupplyOfShares = UD60x18.wrap(totalShares);
+        UD60x18 currentSupplyOfShares = convert(totalShares);
 
-        UD60x18 supplyOfSharesAfterRedeem = currentSupplyOfShares.sub(UD60x18.wrap(shares));
+        UD60x18 supplyOfSharesAfterRedeem = currentSupplyOfShares.sub(convert(shares));
 
-        return _convertToAssets(supplyOfSharesAfterRedeem, currentSupplyOfShares).unwrap();
+        return convert(_convertToAssets(supplyOfSharesAfterRedeem, currentSupplyOfShares));
     }
 
     /// @inheritdoc BaseCurve
@@ -134,7 +133,7 @@ contract ProgressiveCurve is BaseCurve {
         override
         returns (uint256 assets)
     {
-        return _convertToAssets(UD60x18.wrap(totalShares), UD60x18.wrap(totalShares + shares)).unwrap();
+        return convert(_convertToAssets(convert(totalShares), convert(totalShares + shares)));
     }
 
     /// @inheritdoc BaseCurve
@@ -151,9 +150,8 @@ contract ProgressiveCurve is BaseCurve {
         override
         returns (uint256 shares)
     {
-        UD60x18 currentSupplyOfShares = UD60x18.wrap(totalShares);
-        return currentSupplyOfShares.sub(currentSupplyOfShares.powu(2).sub(UD60x18.wrap(assets).div(HALF_SLOPE)).sqrt())
-            .unwrap();
+        UD60x18 currentSupplyOfShares = convert(totalShares);
+        return convert(currentSupplyOfShares.sub(currentSupplyOfShares.powu(2).sub(convert(assets).div(HALF_SLOPE)).sqrt()));
     }
 
     /// @inheritdoc BaseCurve
@@ -165,7 +163,7 @@ contract ProgressiveCurve is BaseCurve {
     /// @dev And the slope ($m$) determines how quickly the price increases
     /// @dev TLDR: Each new share costs more than the last
     function currentPrice(uint256 totalShares) public view override returns (uint256 sharePrice) {
-        return UD60x18.wrap(totalShares).mul(SLOPE).unwrap();
+        return convert(convert(totalShares).mul(SLOPE));
     }
 
     /// @inheritdoc BaseCurve
@@ -183,9 +181,8 @@ contract ProgressiveCurve is BaseCurve {
         returns (uint256 shares)
     {
         require(assets > 0, "Asset amount must be greater than zero");
-        UD60x18 currentSupplyOfShares = UD60x18.wrap(totalShares);
-        return currentSupplyOfShares.powu(2).add(UD60x18.wrap(assets).div(HALF_SLOPE)).sqrt().sub(currentSupplyOfShares)
-            .unwrap();
+        UD60x18 currentSupplyOfShares = convert(totalShares);
+        return convert(currentSupplyOfShares.powu(2).add(convert(assets).div(HALF_SLOPE)).sqrt().sub(currentSupplyOfShares));
     }
 
     /// @inheritdoc BaseCurve
@@ -205,9 +202,9 @@ contract ProgressiveCurve is BaseCurve {
         returns (uint256 assets)
     {
         require(totalShares >= shares, "PC: Under supply of shares");
-        UD60x18 currentSupplyOfShares = UD60x18.wrap(totalShares);
-        UD60x18 supplyOfSharesAfterRedeem = currentSupplyOfShares.sub(UD60x18.wrap(shares));
-        return _convertToAssets(supplyOfSharesAfterRedeem, currentSupplyOfShares).unwrap();
+        UD60x18 currentSupplyOfShares = convert(totalShares);
+        UD60x18 supplyOfSharesAfterRedeem = currentSupplyOfShares.sub(convert(shares));
+        return convert(_convertToAssets(supplyOfSharesAfterRedeem, currentSupplyOfShares));
     }
 
     /**

--- a/src/ProgressiveCurve.sol
+++ b/src/ProgressiveCurve.sol
@@ -63,7 +63,7 @@ contract ProgressiveCurve is BaseCurve {
         require(slope18 > 0, "PC: Slope must be > 0");
 
         SLOPE = UD60x18.wrap(slope18);
-        HALF_SLOPE = SLOPE.div(UD60x18.wrap(2));
+        HALF_SLOPE = UD60x18.wrap(slope18 / 2);
 
         // Find max values
         // powu(2) will overflow first, therefore maximum totalShares is sqrt(MAX_UD60x18)
@@ -163,7 +163,8 @@ contract ProgressiveCurve is BaseCurve {
     /// @dev And the slope ($m$) determines how quickly the price increases
     /// @dev TLDR: Each new share costs more than the last
     function currentPrice(uint256 totalShares) public view override returns (uint256 sharePrice) {
-        return convert(convert(totalShares).mul(SLOPE));
+        // console.log("ProgressiveCurve: currentSharePrice is %e", convert(totalShares).mul(SLOPE).unwrap());
+        return convert(totalShares).mul(SLOPE).unwrap();
     }
 
     /// @inheritdoc BaseCurve

--- a/src/interfaces/IBaseCurve.sol
+++ b/src/interfaces/IBaseCurve.sol
@@ -82,6 +82,6 @@ interface IBaseCurve {
 
     /// @notice Get the current price of a share
     /// @param totalShares Total quantity of shares already awarded by the curve
-    /// @return sharePrice The current price of a share
+    /// @return sharePrice The current price of a share, scaled by 1e18
     function currentPrice(uint256 totalShares) external view returns (uint256 sharePrice);
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -117,7 +117,7 @@ contract BaseTest is Test {
         // Testing for offset curve:
         // - 7e13 - 0 - 36%
         // - 7e13 - 10 - 36% initial dropoff
-        address offsetCurve = address(new OffsetProgressiveCurve("Offset Curve", 1, 1e17));
+        address offsetCurve = address(new OffsetProgressiveCurve("Offset Curve", 2, 1e17));
         BondingCurveRegistry(c.bondingCurve.registry).addBondingCurve(offsetCurve);
 
         // address progressiveCurve = address(

--- a/test/EthMultiVaultBase.sol
+++ b/test/EthMultiVaultBase.sol
@@ -82,7 +82,7 @@ contract EthMultiVaultBase is Test {
 
         address linearCurve = address(new LinearCurve("Linear Curve"));
         BondingCurveRegistry(bondingCurveRegistry).addBondingCurve(linearCurve);
-        address progressiveCurve = address(new ProgressiveCurve("Progressive Curve", 0.00007054e18)); // Because minDeposit is 0.0003 ether
+        address progressiveCurve = address(new ProgressiveCurve("Progressive Curve", 2));
         BondingCurveRegistry(bondingCurveRegistry).addBondingCurve(progressiveCurve);
 
         IEthMultiVault.BondingCurveConfig memory bondingCurveConfig =
@@ -162,6 +162,10 @@ contract EthMultiVaultBase is Test {
 
     function currentSharePrice(uint256 id) public view returns (uint256) {
         return ethMultiVault.currentSharePrice(id);
+    }
+
+    function currentSharePriceCurve(uint256 id, uint256 curveId) public view returns (uint256) {
+        return ethMultiVault.currentSharePriceCurve(id, curveId);
     }
 
     function getApproval(address receiver, address sender) public view returns (bool) {

--- a/test/unit/EthMultiVault/Fees.t.sol
+++ b/test/unit/EthMultiVault/Fees.t.sol
@@ -9,7 +9,7 @@ import {EthMultiVaultHelpers} from "test/helpers/EthMultiVaultHelpers.sol";
 
 contract FeesTest is EthMultiVaultBase, EthMultiVaultHelpers {
     uint256 constant CURVE_ID = 2;
-    uint256 constant NUM_CURVE_OPERATIONS = 50;
+    uint256 constant NUM_CURVE_OPERATIONS = 500;
 
     struct CurveOperation {
         uint256 entryFee;
@@ -128,5 +128,48 @@ contract FeesTest is EthMultiVaultBase, EthMultiVaultHelpers {
         uint256 expectedSharePriceIncrease =
             (aliceFinalAssets * PRECISION) / aliceShares - (aliceInitialAssets * PRECISION) / aliceInitialShares;
         assertEq(sharePriceIncrease, expectedSharePriceIncrease, "Share price increase should match fees per share");
+    }
+
+    function testFeesMakeSenseInBondingCurve() public {
+        // Create atom
+        vm.startPrank(alice);
+        uint256 testAtomCost = getAtomCost();
+        uint256 atomId = ethMultiVault.createAtom{value: testAtomCost}("atom1");
+
+        // Alice deposits into pro rata vault
+        uint256 aliceInitialShares = ethMultiVault.depositAtomCurve{value: 1 ether}(alice, atomId, 2);
+        console.log("Alice bought %e shares for 1 ether", aliceInitialShares);
+        vm.stopPrank();
+
+        uint256 sharePrice = ethMultiVault.currentSharePriceCurve(atomId, 2);
+        console.log("Share price is %e", sharePrice);
+        (uint256 totalAssetsInVault,) = ethMultiVault.getCurveVaultState(atomId, 2);
+        console.log("Total assets in vault is %e", totalAssetsInVault);
+        // Get Alice's state
+        vm.startPrank(alice);
+        (uint256 aliceShares, uint256 aliceFinalAssets) = ethMultiVault.getVaultStateForUserCurve(atomId, 2, alice);
+        console.log("Alice has %e shares and %e assets", aliceShares, aliceFinalAssets);
+
+        vm.startPrank(bob);
+        vm.deal(bob, 1 ether * NUM_CURVE_OPERATIONS);
+        uint256 bobInitialAssets = 1 ether * NUM_CURVE_OPERATIONS;
+        uint256 bobFinalAssets = bobInitialAssets;
+        for (uint256 i = 0; i < NUM_CURVE_OPERATIONS; i++) {
+            // Deposit
+            uint256 bobShares = ethMultiVault.depositAtomCurve{value: 1 ether}(bob, atomId, 2);
+            bobFinalAssets -= 1 ether;
+            // Redeem
+            uint256 bobAssets = ethMultiVault.redeemAtomCurve(bobShares, bob, atomId, 2);
+            bobFinalAssets += bobAssets;
+        }
+        console.log("Bob lost %e assets depositing and redeeming in the curve %d times", bobInitialAssets - bobFinalAssets, NUM_CURVE_OPERATIONS);
+        console.log("Bob has %e assets", bobFinalAssets);
+
+        (aliceShares, aliceFinalAssets) = ethMultiVault.getVaultStateForUserCurve(atomId, 2, alice);
+        console.log("Alice now has %e shares and %e assets", aliceShares, aliceFinalAssets);
+            sharePrice = ethMultiVault.currentSharePriceCurve(atomId, 2);
+        console.log("Share price is now %e", sharePrice);
+        (totalAssetsInVault,) = ethMultiVault.getCurveVaultState(atomId, 2);
+        console.log("Total assets in vault is now %e", totalAssetsInVault);
     }
 }

--- a/test/unit/EthMultiVault/UpgradeTo.t.sol
+++ b/test/unit/EthMultiVault/UpgradeTo.t.sol
@@ -120,7 +120,7 @@ contract UpgradeTo is Test {
 
         address linearCurve = address(new LinearCurve("Linear Curve"));
         bondingCurveRegistry.addBondingCurve(linearCurve);
-        address progressiveCurve = address(new ProgressiveCurve("Progressive Curve", 0.00007054e18));
+        address progressiveCurve = address(new ProgressiveCurve("Progressive Curve", 2));
         bondingCurveRegistry.addBondingCurve(progressiveCurve);
 
         IEthMultiVault.BondingCurveConfig memory bondingCurveConfig =

--- a/test/unit/UD60x18.t.sol
+++ b/test/unit/UD60x18.t.sol
@@ -16,8 +16,7 @@ contract UD60x18Test is Test {
       console.log("x = ", x);
       console.log("y = ", y);
       console.log("z = ", z);
-      vm.expectRevert();
-      assertEq(z, 35);
+      assertNotEq(z, 35);
     }
 
     function testConvertUnwrap() public {
@@ -28,8 +27,7 @@ contract UD60x18Test is Test {
       console.log("x = ", x);
       console.log("y = ", y);
       console.log("z = ", z);
-      vm.expectRevert();
-      assertEq(z, 35);
+      assertNotEq(z, 35);
     }
 
     function testConvert() public {
@@ -63,8 +61,7 @@ contract UD60x18Test is Test {
       console.log("x = ", x);
       console.log("y = ", y);
       console.log("z = ", z);
-      vm.expectRevert();
-      assertEq(z, 5);
+      assertNotEq(z, 5);
     }
 
     function testE18Wrap() public {

--- a/test/unit/UD60x18.t.sol
+++ b/test/unit/UD60x18.t.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {UD60x18, ud, convert} from "@prb/math/UD60x18.sol";
+import {console2 as console} from "forge-std/console2.sol";
+
+
+contract UD60x18Test is Test {
+
+    function testWrap() public {
+      console.log("wrap(5).mul(wrap(7)).unwrap()");
+      uint256 x = 5;
+      uint256 y = 7;
+      uint256 z = UD60x18.wrap(x).mul(UD60x18.wrap(y)).unwrap();
+      console.log("x = ", x);
+      console.log("y = ", y);
+      console.log("z = ", z);
+      vm.expectRevert();
+      assertEq(z, 35);
+    }
+
+    function testConvertUnwrap() public {
+      console.log("convert(5).mul(convert(7)).unwrap()");
+      uint256 x = 5;
+      uint256 y = 7;
+      uint256 z = convert(x).mul(convert(y)).unwrap();
+      console.log("x = ", x);
+      console.log("y = ", y);
+      console.log("z = ", z);
+      vm.expectRevert();
+      assertEq(z, 35);
+    }
+
+    function testConvert() public {
+      console.log("convert(convert(5).mul(convert(7)))");
+      uint256 x = 5;
+      uint256 y = 7;
+      uint256 z = convert(convert(x).mul(convert(y)));
+
+      console.log("x = ", x);
+      console.log("y = ", y);
+      console.log("z = ", z);
+      assertEq(z, 35);
+    }
+
+    function testDecimal() public {
+      uint256 x = 10;
+      uint256 y = 3;
+      uint256 z = convert(convert(x).div(convert(y)));
+      console.log("convert(convert(10).div(convert(3)))");
+      console.log("x = ", x);
+      console.log("y = ", y);
+      console.log("z = ", z);
+      assertEq(z, 3);
+    }
+
+    function testE18() public {
+      uint256 x = 10;
+      uint256 y = 0.5e18;
+      uint256 z = convert(convert(x).mul(convert(y)));
+      console.log("convert(convert(10).mul(convert(0.5e18)))");
+      console.log("x = ", x);
+      console.log("y = ", y);
+      console.log("z = ", z);
+      vm.expectRevert();
+      assertEq(z, 5);
+    }
+
+    function testE18Wrap() public {
+      uint256 x = 10;
+      uint256 y = 0.5e18;
+      uint256 z = convert(convert(x).mul(UD60x18.wrap(y)));
+      console.log("convert(convert(10).mul(wrap(0.5e18)))");
+      console.log("x = ", x);
+      console.log("y = ", y);
+      console.log("z = ", z);
+      assertEq(z, 5);
+    }
+} 


### PR DESCRIPTION
This PR fixes an issue where the UD60x18 values were being scaled down by 1e18.

This phenomena was observed by the auditors:

```
Ran 6 tests for test/unit/UD60x18.t.sol:UD60x18Test
[PASS] testConvert() (gas: 8630)
Logs:
  convert(convert(5).mul(convert(7)))
  x =  5
  y =  7
  z =  35

[PASS] testConvertUnwrap() (gas: 8697)
Logs:
  convert(5).mul(convert(7)).unwrap()
  x =  5
  y =  7
  z =  35000000000000000000

[PASS] testDecimal() (gas: 8479)
Logs:
  convert(convert(10).div(convert(3)))
  x =  10
  y =  3
  z =  3

[PASS] testE18() (gas: 8930)
Logs:
  convert(convert(10).mul(convert(0.5e18)))
  x =  10
  y =  500000000000000000
  z =  5000000000000000000

[PASS] testE18Wrap() (gas: 8337)
Logs:
  convert(convert(10).mul(wrap(0.5e18)))
  x =  10
  y =  500000000000000000
  z =  5

[PASS] testWrap() (gas: 8718)
Logs:
  wrap(5).mul(wrap(7)).unwrap()
  x =  5
  y =  7
  z =  0
```

So we have updated the mathematical operations in the ProgressiveCurve and OffsetProgressiveCurve to use `convert()` instead of `wrap()` and `unwrap()` where it makes sense to do so.  Constructor inputs remain the same, and assume a 1e18 decimal scaling.

Edit:
This also addresses `[3.6 currentSharePrice and currentSharePriceCurve Return Price With Orders of Magnitude Inflated by generalConfig.decimalPrecision Minor]()` by ensuring the order of magnitude is consistently 1e18, as share price is often < 1.0.

