### PR TITLE
fix camelCase for 'id' terms in events

### DIFF
--- a/src/EthMultiVault.sol
+++ b/src/EthMultiVault.sol
@@ -650,7 +650,7 @@ contract EthMultiVault is IEthMultiVault, Initializable, ReentrancyGuardUpgradea
         // check if atom already exists based on hash
         bytes32 hash = keccak256(atomUri);
         if (atomsByHash[hash] != 0) {
-            revert Errors.EthMultiVault_AtomExists(atomUri);
+            revert Errors.EthMultiVault_AtomExists(atomUri, atomsByHash[hash]);
         }
 
         // calculate user deposit amount

--- a/src/interfaces/IEthMultiVault.sol
+++ b/src/interfaces/IEthMultiVault.sol
@@ -193,8 +193,8 @@ interface IEthMultiVault {
     /// @param creator address of the atom creator
     /// @param atomWallet address of the atom's associated abstract account
     /// @param atomData the atom's respective string
-    /// @param vaultID the vault id of the atom
-    event AtomCreated(address indexed creator, address indexed atomWallet, bytes atomData, uint256 vaultID);
+    /// @param vaultId the vault id of the atom
+    event AtomCreated(address indexed creator, address indexed atomWallet, bytes atomData, uint256 vaultId);
 
     /// @notice emitted upon creation of a triple
     ///
@@ -202,9 +202,9 @@ interface IEthMultiVault {
     /// @param subjectId the triple's respective subject atom
     /// @param predicateId the triple's respective predicate atom
     /// @param objectId the triple's respective object atom
-    /// @param vaultID the vault id of the triple
+    /// @param vaultId the vault id of the triple
     event TripleCreated(
-        address indexed creator, uint256 subjectId, uint256 predicateId, uint256 objectId, uint256 vaultID
+        address indexed creator, uint256 subjectId, uint256 predicateId, uint256 objectId, uint256 vaultId
     );
 
     /// @notice emitted upon the transfer of fees to the protocol multisig

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -10,7 +10,7 @@ library Errors {
     error EthMultiVault_AdminOnly();
     error EthMultiVault_ArraysNotSameLength();
     error EthMultiVault_AtomDoesNotExist(uint256 atomId);
-    error EthMultiVault_AtomExists(bytes atomUri);
+    error EthMultiVault_AtomExists(bytes atomUri, uint256 atomId);
     error EthMultiVault_AtomUriTooLong();
     error EthMultiVault_BurnFromZeroAddress();
     error EthMultiVault_BurnInsufficientBalance();


### PR DESCRIPTION
Just fixing capitalization in an event.

Also -- added existing atomId to atomExists error because it should be there.  Caller probably knows the URI they provided, and not the atomId.