### PR TITLE
Chore: Declare Solc Version in foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 src = "src"
 out = "out"
+solc = "0.8.28"
 libs = ["lib", "node_modules"]
 ffi = true
 ast = true


### PR DESCRIPTION
Declare the required solc version. Prevents build errors if local machine is not using the minimum required solc version.